### PR TITLE
feat: improve null handling

### DIFF
--- a/src/portabellas/containers/_cell/_cell.py
+++ b/src/portabellas/containers/_cell/_cell.py
@@ -1024,18 +1024,18 @@ class Cell[T_co](ABC):
         self,
         other: object,
         *,
-        propagate_nulls: bool = True,
+        propagate_nulls: bool = False,
     ) -> Cell[bool | None]:
         """
         Check if equal to a value. The default behavior is equivalent to the `==` operator.
 
         Null values (indicated by `None`) are handled as follows:
 
-        - If `propagate_nulls` is `True` (default), the result will be a null value if either the cell or
-          the other value is a null value. Here, `None == None` is `None`. The intuition is that we do not know the
-          result of the comparison if we do not know the values, which is consistent with the other cell operations.
-        - If `propagate_nulls` is `False`, `None` will be treated as a regular value. Here, `None == None`
+        - If `propagate_nulls` is `False` (default), `None` will be treated as a regular value. Here, `None == None`
           is `True`. This behavior is useful, if you want to work with null values, e.g. to filter them out.
+        - If `propagate_nulls` is `True`, the result will be a null value if either the cell or
+          the other value is a null value. Here, `None == None` is `None`. The intuition is that we do not know the
+          result of the comparison if we do not know the values, which is consistent with SQL three-valued logic.
 
         Parameters
         ----------
@@ -1061,7 +1061,7 @@ class Cell[T_co](ABC):
         +=======+
         | false |
         | true  |
-        | null  |
+        | false |
         +-------+
 
         >>> column.map(lambda cell: cell == 2)
@@ -1072,10 +1072,10 @@ class Cell[T_co](ABC):
         +=======+
         | false |
         | true  |
-        | null  |
+        | false |
         +-------+
 
-        >>> column.map(lambda cell: cell.eq(2, propagate_nulls=False))
+        >>> column.map(lambda cell: cell.eq(2, propagate_nulls=True))
         +-------+
         | a     |
         | ---   |
@@ -1083,7 +1083,7 @@ class Cell[T_co](ABC):
         +=======+
         | false |
         | true  |
-        | false |
+        | null  |
         +-------+
         """
 
@@ -1092,18 +1092,18 @@ class Cell[T_co](ABC):
         self,
         other: object,
         *,
-        propagate_nulls: bool = True,
+        propagate_nulls: bool = False,
     ) -> Cell[bool | None]:
         """
         Check if not equal to a value. The default behavior is equivalent to the `!=` operator.
 
         Null values (indicated by `None`) are handled as follows:
 
-        - If `propagate_nulls` is `True` (default), the result will be a null value if either the cell or
-          the other value is a null value. Here, `None != None` is `None`. The intuition is that we do not know the
-          result of the comparison if we do not know the values, which is consistent with the other cell operations.
-        - If `propagate_nulls` is `False`, `None` will be treated as a regular value. Here, `None != None`
+        - If `propagate_nulls` is `False` (default), `None` will be treated as a regular value. Here, `None != None`
           is `False`. This behavior is useful, if you want to work with null values, e.g. to filter them out.
+        - If `propagate_nulls` is `True`, the result will be a null value if either the cell or
+          the other value is a null value. Here, `None != None` is `None`. The intuition is that we do not know the
+          result of the comparison if we do not know the values, which is consistent with SQL three-valued logic.
 
         Parameters
         ----------
@@ -1129,7 +1129,7 @@ class Cell[T_co](ABC):
         +=======+
         | true  |
         | false |
-        | null  |
+        | true  |
         +-------+
 
         >>> column.map(lambda cell: cell != 2)
@@ -1140,10 +1140,10 @@ class Cell[T_co](ABC):
         +=======+
         | true  |
         | false |
-        | null  |
+        | true  |
         +-------+
 
-        >>> column.map(lambda cell: cell.neq(2, propagate_nulls=False))
+        >>> column.map(lambda cell: cell.neq(2, propagate_nulls=True))
         +-------+
         | a     |
         | ---   |
@@ -1151,7 +1151,7 @@ class Cell[T_co](ABC):
         +=======+
         | true  |
         | false |
-        | true  |
+        | null  |
         +-------+
         """
 

--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -72,7 +72,7 @@ class ExprCell[T](Cell[T]):
 
     def __eq__(self, other: object) -> Cell[bool | None]:  # type: ignore[override]
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__eq__(other_expr))
+        return ExprCell(self._expression.eq_missing(other_expr))
 
     def __ge__(self, other: object) -> Cell[bool | None]:
         other_expr = _to_polars_expression(other)
@@ -92,7 +92,7 @@ class ExprCell[T](Cell[T]):
 
     def __ne__(self, other: object) -> Cell[bool | None]:  # type: ignore[override]
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__ne__(other_expr))
+        return ExprCell(self._expression.ne_missing(other_expr))
 
     # Numeric operators --------------------------------------------------------
 
@@ -181,7 +181,7 @@ class ExprCell[T](Cell[T]):
     # Comparison operations
     # ------------------------------------------------------------------------------------------------------------------
 
-    def eq(self, other: object, *, propagate_nulls: bool = True) -> Cell[bool | None]:
+    def eq(self, other: object, *, propagate_nulls: bool = False) -> Cell[bool | None]:
         other_expr = _to_polars_expression(other)
 
         if propagate_nulls:
@@ -189,7 +189,7 @@ class ExprCell[T](Cell[T]):
         else:
             return ExprCell(self._expression.eq_missing(other_expr))
 
-    def neq(self, other: object, *, propagate_nulls: bool = True) -> Cell[bool | None]:
+    def neq(self, other: object, *, propagate_nulls: bool = False) -> Cell[bool | None]:
         other_expr = _to_polars_expression(other)
 
         if propagate_nulls:

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -402,7 +402,7 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: Literal[True] = ...,
+        ignore_nulls: Literal[True] = ...,
     ) -> bool: ...
 
     @overload
@@ -410,14 +410,14 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool,
+        ignore_nulls: bool,
     ) -> bool | None: ...
 
     def all(
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool = True,
+        ignore_nulls: bool = True,
     ) -> bool | None:
         """
         Check whether all values in the column satisfy the predicate.
@@ -433,7 +433,7 @@ class Column[T_co](Sequence[T_co]):
         * True, if the predicate always returns True or None.
         * False, if the predicate returns False at least once.
 
-        You can instead enable Kleene logic by setting `ignore_unknown=False`. In this case, this method returns
+        You can instead enable Kleene logic by setting `ignore_nulls=False`. In this case, this method returns
 
         * True, if the predicate always returns True.
         * False, if the predicate returns False at least once.
@@ -443,8 +443,8 @@ class Column[T_co](Sequence[T_co]):
         ----------
         predicate:
             The predicate to apply to each value.
-        ignore_unknown:
-            Whether to ignore cases where the truthiness of the predicate is unknown.
+        ignore_nulls:
+            Whether to ignore cases where the truthiness of the predicate is unknown due to null values.
 
         Returns
         -------
@@ -461,13 +461,13 @@ class Column[T_co](Sequence[T_co]):
         >>> column.all(lambda cell: cell < 3)
         False
 
-        >>> print(column.all(lambda cell: cell > 0, ignore_unknown=False))
+        >>> print(column.all(lambda cell: cell > 0, ignore_nulls=False))
         None
 
-        >>> column.all(lambda cell: cell < 3, ignore_unknown=False)
+        >>> column.all(lambda cell: cell < 3, ignore_nulls=False)
         False
         """
-        expression = predicate(ExprCell(pl.col(self.name)))._polars_expression.all(ignore_nulls=ignore_unknown)
+        expression = predicate(ExprCell(pl.col(self.name)))._polars_expression.all(ignore_nulls=ignore_nulls)
         frame = safely_collect_lazy_frame(self._lazy_frame.select(expression))
 
         return frame.item()
@@ -477,7 +477,7 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: Literal[True] = ...,
+        ignore_nulls: Literal[True] = ...,
     ) -> bool: ...
 
     @overload
@@ -485,14 +485,14 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool,
+        ignore_nulls: bool,
     ) -> bool | None: ...
 
     def any(
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool = True,
+        ignore_nulls: bool = True,
     ) -> bool | None:
         """
         Check whether any value in the column satisfies the predicate.
@@ -508,7 +508,7 @@ class Column[T_co](Sequence[T_co]):
         * True, if the predicate returns True at least once.
         * False, if the predicate always returns False or None.
 
-        You can instead enable Kleene logic by setting `ignore_unknown=False`. In this case, this method returns
+        You can instead enable Kleene logic by setting `ignore_nulls=False`. In this case, this method returns
 
         * True, if the predicate returns True at least once.
         * False, if the predicate always returns False.
@@ -518,8 +518,8 @@ class Column[T_co](Sequence[T_co]):
         ----------
         predicate:
             The predicate to apply to each value.
-        ignore_unknown:
-            Whether to ignore cases where the truthiness of the predicate is unknown.
+        ignore_nulls:
+            Whether to ignore cases where the truthiness of the predicate is unknown due to null values.
 
         Returns
         -------
@@ -536,13 +536,13 @@ class Column[T_co](Sequence[T_co]):
         >>> column.any(lambda cell: cell < 0)
         False
 
-        >>> column.any(lambda cell: cell > 2, ignore_unknown=False)
+        >>> column.any(lambda cell: cell > 2, ignore_nulls=False)
         True
 
-        >>> print(column.any(lambda cell: cell < 0, ignore_unknown=False))
+        >>> print(column.any(lambda cell: cell < 0, ignore_nulls=False))
         None
         """
-        expression = predicate(ExprCell(pl.col(self.name)))._polars_expression.any(ignore_nulls=ignore_unknown)
+        expression = predicate(ExprCell(pl.col(self.name)))._polars_expression.any(ignore_nulls=ignore_nulls)
         frame = safely_collect_lazy_frame(self._lazy_frame.select(expression))
 
         return frame.item()
@@ -552,7 +552,7 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: Literal[True] = ...,
+        ignore_nulls: Literal[True] = ...,
     ) -> int: ...
 
     @overload
@@ -560,14 +560,14 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool,
+        ignore_nulls: bool,
     ) -> int | None: ...
 
     def count_if(
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool = True,
+        ignore_nulls: bool = True,
     ) -> int | None:
         """
         Count how many values in the column satisfy the predicate.
@@ -581,15 +581,15 @@ class Column[T_co](Sequence[T_co]):
         By default, cases where the truthiness of the predicate is unknown are ignored and this method returns how
         often the predicate returns True.
 
-        You can instead enable Kleene logic by setting `ignore_unknown=False`. In this case, this method returns None if
+        You can instead enable Kleene logic by setting `ignore_nulls=False`. In this case, this method returns None if
         the predicate returns None at least once. Otherwise, it still returns how often the predicate returns True.
 
         Parameters
         ----------
         predicate:
             The predicate to apply to each value.
-        ignore_unknown:
-            Whether to ignore cases where the truthiness of the predicate is unknown.
+        ignore_nulls:
+            Whether to ignore cases where the truthiness of the predicate is unknown due to null values.
 
         Returns
         -------
@@ -603,14 +603,14 @@ class Column[T_co](Sequence[T_co]):
         >>> column.count_if(lambda cell: cell > 1)
         2
 
-        >>> print(column.count_if(lambda cell: cell < 0, ignore_unknown=False))
+        >>> print(column.count_if(lambda cell: cell < 0, ignore_nulls=False))
         None
         """
         expression = predicate(ExprCell(pl.col(self.name)))._polars_expression
         frame = safely_collect_lazy_frame(self._lazy_frame.select(expression))
         series = frame.to_series()
 
-        if ignore_unknown or not series.has_nulls():
+        if ignore_nulls or not series.has_nulls():
             return int(series.sum())
 
         return None
@@ -620,7 +620,7 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: Literal[True] = ...,
+        ignore_nulls: Literal[True] = ...,
     ) -> bool: ...
 
     @overload
@@ -628,14 +628,14 @@ class Column[T_co](Sequence[T_co]):
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool,
+        ignore_nulls: bool,
     ) -> bool | None: ...
 
     def none(
         self,
         predicate: Callable[[Cell[T_co]], Cell[bool | None]],
         *,
-        ignore_unknown: bool = True,
+        ignore_nulls: bool = True,
     ) -> bool | None:
         """
         Check whether no value in the column satisfies the predicate.
@@ -651,7 +651,7 @@ class Column[T_co](Sequence[T_co]):
         * True, if the predicate always returns False or None.
         * False, if the predicate returns True at least once.
 
-        You can instead enable Kleene logic by setting `ignore_unknown=False`. In this case, this method returns
+        You can instead enable Kleene logic by setting `ignore_nulls=False`. In this case, this method returns
 
         * True, if the predicate always returns False.
         * False, if the predicate returns True at least once.
@@ -661,8 +661,8 @@ class Column[T_co](Sequence[T_co]):
         ----------
         predicate:
             The predicate to apply to each value.
-        ignore_unknown:
-            Whether to ignore cases where the truthiness of the predicate is unknown.
+        ignore_nulls:
+            Whether to ignore cases where the truthiness of the predicate is unknown due to null values.
 
         Returns
         -------
@@ -679,13 +679,13 @@ class Column[T_co](Sequence[T_co]):
         >>> column.none(lambda cell: cell > 2)
         False
 
-        >>> print(column.none(lambda cell: cell < 0, ignore_unknown=False))
+        >>> print(column.none(lambda cell: cell < 0, ignore_nulls=False))
         None
 
-        >>> column.none(lambda cell: cell > 2, ignore_unknown=False)
+        >>> column.none(lambda cell: cell > 2, ignore_nulls=False)
         False
         """
-        expression = predicate(ExprCell(pl.col(self.name)))._polars_expression.not_().all(ignore_nulls=ignore_unknown)
+        expression = predicate(ExprCell(pl.col(self.name)))._polars_expression.not_().all(ignore_nulls=ignore_nulls)
         frame = safely_collect_lazy_frame(self._lazy_frame.select(expression))
 
         return frame.item()

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1025,7 +1025,7 @@ class Table:
         self,
         predicate: Callable[[Row], Cell[bool | None]],
         *,
-        ignore_unknown: Literal[True] = ...,
+        ignore_nulls: Literal[True] = ...,
     ) -> int: ...
 
     @overload
@@ -1033,14 +1033,14 @@ class Table:
         self,
         predicate: Callable[[Row], Cell[bool | None]],
         *,
-        ignore_unknown: bool,
+        ignore_nulls: bool,
     ) -> int | None: ...
 
     def count_rows_if(
         self,
         predicate: Callable[[Row], Cell[bool | None]],
         *,
-        ignore_unknown: bool = True,
+        ignore_nulls: bool = True,
     ) -> int | None:
         """
         Count how many rows in the table satisfy the predicate.
@@ -1054,15 +1054,15 @@ class Table:
         By default, cases where the truthiness of the predicate is unknown are ignored and this method returns how
         often the predicate returns True.
 
-        You can instead enable Kleene logic by setting `ignore_unknown=False`. In this case, this method returns None if
+        You can instead enable Kleene logic by setting `ignore_nulls=False`. In this case, this method returns None if
         the predicate returns None at least once. Otherwise, it still returns how often the predicate returns True.
 
         Parameters
         ----------
         predicate:
             The predicate to apply to each row.
-        ignore_unknown:
-            Whether to ignore cases where the truthiness of the predicate is unknown.
+        ignore_nulls:
+            Whether to ignore cases where the truthiness of the predicate is unknown due to null values.
 
         Returns
         -------
@@ -1079,7 +1079,7 @@ class Table:
         expression = predicate(ExprRow(self))._polars_expression
         series = safely_collect_lazy_frame(self._lazy_frame.select(expression.alias("count"))).get_column("count")
 
-        if ignore_unknown or series.null_count() == 0:
+        if ignore_nulls or series.null_count() == 0:
             return int(series.sum())
         else:
             return None

--- a/tests/portabellas/containers/_cell/test_eq.py
+++ b/tests/portabellas/containers/_cell/test_eq.py
@@ -12,8 +12,9 @@ from tests.helpers import assert_cell_operation_works
         pytest.param(3, 1.5, False, id="int - float"),
         pytest.param(1.5, 3, False, id="float - int"),
         pytest.param(1.5, 1.5, True, id="float - float"),
-        pytest.param(None, 3, None, id="left is None"),
-        pytest.param(3, None, None, id="right is None"),
+        pytest.param(None, 3, False, id="left is None"),
+        pytest.param(3, None, False, id="right is None"),
+        pytest.param(None, None, True, id="both are None"),
     ],
 )
 class TestShouldComputeEquality:
@@ -59,19 +60,21 @@ class TestShouldComputeEquality:
 @pytest.mark.parametrize(
     ("value1", "value2", "expected"),
     [
-        pytest.param(None, 3, False, id="left is None"),
-        pytest.param(3, None, False, id="right is None"),
-        pytest.param(None, None, True, id="both are None"),
+        pytest.param(3, 3, True, id="equal"),
+        pytest.param(1, 3, False, id="unequal"),
+        pytest.param(None, 3, None, id="left is None"),
+        pytest.param(3, None, None, id="right is None"),
+        pytest.param(None, None, None, id="both are None"),
     ],
 )
-class TestShouldComputeEqualityWithoutPropagatingNulls:
+class TestShouldComputeEqualityWithPropagatingNulls:
     def test_named_method(
         self,
         value1: float | None,
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.eq(value2, propagate_nulls=False), expected)
+        assert_cell_operation_works(value1, lambda cell: cell.eq(value2, propagate_nulls=True), expected)
 
     def test_named_method_wrapped_in_cell(
         self,
@@ -81,6 +84,6 @@ class TestShouldComputeEqualityWithoutPropagatingNulls:
     ) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.eq(ExprCell(pl.lit(value2)), propagate_nulls=False),
+            lambda cell: cell.eq(ExprCell(pl.lit(value2)), propagate_nulls=True),
             expected,
         )

--- a/tests/portabellas/containers/_cell/test_neq.py
+++ b/tests/portabellas/containers/_cell/test_neq.py
@@ -12,8 +12,9 @@ from tests.helpers import assert_cell_operation_works
         pytest.param(3, 1.5, True, id="int - float"),
         pytest.param(1.5, 3, True, id="float - int"),
         pytest.param(1.5, 1.5, False, id="float - float"),
-        pytest.param(None, 3, None, id="left is None"),
-        pytest.param(3, None, None, id="right is None"),
+        pytest.param(None, 3, True, id="left is None"),
+        pytest.param(3, None, True, id="right is None"),
+        pytest.param(None, None, False, id="both are None"),
     ],
 )
 class TestShouldComputeInequality:
@@ -59,19 +60,21 @@ class TestShouldComputeInequality:
 @pytest.mark.parametrize(
     ("value1", "value2", "expected"),
     [
-        pytest.param(None, 3, True, id="left is None"),
-        pytest.param(3, None, True, id="right is None"),
-        pytest.param(None, None, False, id="both are None"),
+        pytest.param(3, 3, False, id="equal"),
+        pytest.param(1, 3, True, id="unequal"),
+        pytest.param(None, 3, None, id="left is None"),
+        pytest.param(3, None, None, id="right is None"),
+        pytest.param(None, None, None, id="both are None"),
     ],
 )
-class TestShouldComputeInequalityWithoutPropagatingNulls:
+class TestShouldComputeInequalityWithPropagatingNulls:
     def test_named_method(
         self,
         value1: float | None,
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.neq(value2, propagate_nulls=False), expected)
+        assert_cell_operation_works(value1, lambda cell: cell.neq(value2, propagate_nulls=True), expected)
 
     def test_named_method_wrapped_in_cell(
         self,
@@ -81,6 +84,6 @@ class TestShouldComputeInequalityWithoutPropagatingNulls:
     ) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.neq(ExprCell(pl.lit(value2)), propagate_nulls=False),
+            lambda cell: cell.neq(ExprCell(pl.lit(value2)), propagate_nulls=True),
             expected,
         )

--- a/tests/portabellas/containers/_column/test_all.py
+++ b/tests/portabellas/containers/_column/test_all.py
@@ -36,4 +36,4 @@ def test_should_handle_boolean_logic(values: list, expected: bool) -> None:
 )
 def test_should_handle_kleene_logic(values: list, expected: bool | None) -> None:
     column = Column("col1", values)
-    assert column.all(lambda value: value < 2, ignore_unknown=False) == expected
+    assert column.all(lambda value: value < 2, ignore_nulls=False) == expected

--- a/tests/portabellas/containers/_column/test_any.py
+++ b/tests/portabellas/containers/_column/test_any.py
@@ -36,4 +36,4 @@ def test_should_handle_boolean_logic(values: list, expected: bool) -> None:
 )
 def test_should_handle_kleene_logic(values: list, expected: bool | None) -> None:
     column = Column("col1", values)
-    assert column.any(lambda value: value < 2, ignore_unknown=False) == expected
+    assert column.any(lambda value: value < 2, ignore_nulls=False) == expected

--- a/tests/portabellas/containers/_column/test_count_if.py
+++ b/tests/portabellas/containers/_column/test_count_if.py
@@ -36,4 +36,4 @@ def test_should_handle_boolean_logic(values: list, expected: int) -> None:
 )
 def test_should_handle_kleene_logic(values: list, expected: int | None) -> None:
     column = Column("col1", values)
-    assert column.count_if(lambda value: value < 2, ignore_unknown=False) == expected
+    assert column.count_if(lambda value: value < 2, ignore_nulls=False) == expected

--- a/tests/portabellas/containers/_column/test_map.py
+++ b/tests/portabellas/containers/_column/test_map.py
@@ -24,7 +24,7 @@ from portabellas.containers import Cell
         pytest.param(
             lambda: Column("col1", [1, 2, None]),
             lambda cell: cell.eq(2),
-            Column("col1", [False, True, None]),
+            Column("col1", [False, True, False]),
             id="non-empty (computed value)",
         ),
     ],

--- a/tests/portabellas/containers/_column/test_none.py
+++ b/tests/portabellas/containers/_column/test_none.py
@@ -36,4 +36,4 @@ def test_should_handle_boolean_logic(values: list, expected: bool) -> None:
 )
 def test_should_handle_kleene_logic(values: list, expected: bool | None) -> None:
     column = Column("col1", values)
-    assert column.none(lambda value: value < 2, ignore_unknown=False) == expected
+    assert column.none(lambda value: value < 2, ignore_nulls=False) == expected

--- a/tests/portabellas/containers/_table/test_count_rows_if.py
+++ b/tests/portabellas/containers/_table/test_count_rows_if.py
@@ -37,5 +37,5 @@ def test_should_handle_boolean_logic(values: list, expected: int) -> None:
 )
 def test_should_handle_kleene_logic(values: list, expected: int | None) -> None:
     table = Table({"a": values})
-    actual = table.count_rows_if(lambda row: row["a"] < 2, ignore_unknown=False)
+    actual = table.count_rows_if(lambda row: row["a"] < 2, ignore_nulls=False)
     assert actual == expected


### PR DESCRIPTION
Closes #89.

### Summary of Changes

Changed propagate_nulls default from True to False on Cell.eq/Cell.neq.


**Rationale:** Equality with null is semantically unique compared to other operators:
- None == None has a meaningful answer (True), and x == None has a meaningful answer (False for any non-null x). No other operator has this property — None < 5, None + 3, etc. have no sensible non-null result.
- The common pattern cell_a == cell_b where either cell could be null now does the right thing (null == null → True, null == value → False), rather than poisoning the result with None. Adding a new operation cell.is_null() does not help here.
- With the old default, count_rows_if(lambda row: row["b"] == None) silently returned 0, which felt like a bug.

Three-valued logic is still available via propagate_nulls=True for cases that need it.