### PR TITLE
feat: Table.reorder_columns

### DIFF
--- a/src/portabellas/_validation/__init__.py
+++ b/src/portabellas/_validation/__init__.py
@@ -2,6 +2,7 @@ from ._check_bounds import check_bounds
 from ._check_column_has_no_nulls import check_column_has_no_nulls
 from ._check_column_is_numeric import check_column_is_numeric
 from ._check_columns_are_numeric import check_columns_are_numeric
+from ._check_columns_are_permutation import check_columns_are_permutation
 from ._check_columns_dont_exist import check_columns_dont_exist
 from ._check_columns_exist import check_columns_exist
 from ._check_datetime_format import check_and_convert_datetime_format
@@ -17,6 +18,7 @@ __all__ = [
     "check_column_has_no_nulls",
     "check_column_is_numeric",
     "check_columns_are_numeric",
+    "check_columns_are_permutation",
     "check_columns_dont_exist",
     "check_columns_exist",
     "check_indices",

--- a/src/portabellas/_validation/_check_columns_are_permutation.py
+++ b/src/portabellas/_validation/_check_columns_are_permutation.py
@@ -1,0 +1,69 @@
+"""The module name must differ from the function name, so it can be re-exported properly."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from portabellas._utils import compute_duplicates
+from portabellas._validation._check_columns_exist import check_columns_exist
+from portabellas.exceptions import DuplicateColumnError
+
+if TYPE_CHECKING:
+    from portabellas.containers import Table
+    from portabellas.typing import Schema
+
+
+def check_columns_are_permutation(
+    table_or_schema: Table | Schema,
+    column_names: list[str],
+) -> None:
+    """
+    Check whether the given column names are a permutation of the table's column names, and raise an error if not.
+
+    This checks three conditions:
+
+    1. No duplicate column names.
+    2. No unknown column names (names not in the table).
+    3. No missing column names (columns in the table but not in the list).
+
+    Parameters
+    ----------
+    table_or_schema:
+        The table or schema to check against.
+    column_names:
+        The column names to validate.
+
+    Raises
+    ------
+    ColumnNotFoundError
+        If a column name does not exist in the table.
+    DuplicateColumnError
+        If a column name appears more than once.
+    ValueError
+        If a table column is missing from the list.
+    """
+    from portabellas.containers import Table  # circular import  # noqa: PLC0415
+
+    if isinstance(table_or_schema, Table):
+        table_or_schema = table_or_schema.schema
+
+    duplicate_names = compute_duplicates(column_names)
+    if duplicate_names:
+        message = _build_duplicate_error_message(duplicate_names)
+        raise DuplicateColumnError(message) from None
+
+    check_columns_exist(table_or_schema, column_names)
+
+    column_name_set = set(column_names)
+    missing_names = [name for name in table_or_schema.column_names if name not in column_name_set]
+    if missing_names:
+        message = _build_missing_error_message(missing_names)
+        raise ValueError(message) from None
+
+
+def _build_duplicate_error_message(duplicate_names: list[str]) -> str:
+    return f"The column names {duplicate_names} appear more than once."
+
+
+def _build_missing_error_message(missing_names: list[str]) -> str:
+    return f"The following column(s) exist in the table but were not listed: {missing_names}"

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -9,6 +9,7 @@ from portabellas._config import get_polars_config
 from portabellas._utils import compute_duplicates, safely_collect_lazy_frame, safely_collect_lazy_frame_schema
 from portabellas._validation import (
     check_bounds,
+    check_columns_are_permutation,
     check_columns_dont_exist,
     check_columns_exist,
     check_row_counts_are_equal,
@@ -755,6 +756,52 @@ class Table:
 
         return Table._from_polars_lazy_frame(
             self._lazy_frame.rename({old_name: new_name}),
+        )
+
+    def reorder_columns(self, column_names: list[str]) -> Table:
+        """
+        Reorder the columns and return the result as a new table.
+
+        **Note:** The original table is not modified.
+
+        Parameters
+        ----------
+        column_names:
+            The column names in the desired order. Must contain every column in the table exactly once.
+
+        Returns
+        -------
+        new_table:
+            The table with the columns reordered.
+
+        Raises
+        ------
+        ColumnNotFoundError
+            If a column name does not exist in the table.
+        DuplicateColumnError
+            If a column name appears more than once.
+        ValueError
+            If a table column is missing from the list.
+
+        Examples
+        --------
+        >>> from portabellas import Table
+        >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> table.reorder_columns(["b", "a"])
+        +-----+-----+
+        |   b |   a |
+        | --- | --- |
+        | i64 | i64 |
+        +===========+
+        |   4 |   1 |
+        |   5 |   2 |
+        |   6 |   3 |
+        +-----+-----+
+        """
+        check_columns_are_permutation(self, column_names)
+
+        return Table._from_polars_lazy_frame(
+            self._lazy_frame.select(column_names),
         )
 
     def replace_column(

--- a/tests/portabellas/containers/_table/test_reorder_columns.py
+++ b/tests/portabellas/containers/_table/test_reorder_columns.py
@@ -1,0 +1,72 @@
+from collections.abc import Callable
+
+import pytest
+
+from portabellas import Table
+from portabellas.exceptions import ColumnNotFoundError, DuplicateColumnError
+from tests.helpers import assert_tables_are_equal
+
+
+@pytest.mark.parametrize(
+    ("table_factory", "column_names", "expected"),
+    [
+        pytest.param(
+            lambda: Table({}),
+            [],
+            Table({}),
+            id="empty table",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            ["b", "a"],
+            Table({"b": [4, 5, 6], "a": [1, 2, 3]}),
+            id="swap two columns",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}),
+            ["c", "a", "b"],
+            Table({"c": [7, 8, 9], "a": [1, 2, 3], "b": [4, 5, 6]}),
+            id="reorder three columns",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            ["a", "b"],
+            Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            id="same order",
+        ),
+    ],
+)
+class TestHappyPath:
+    def test_should_reorder_columns(
+        self,
+        table_factory: Callable[[], Table],
+        column_names: list[str],
+        expected: Table,
+    ) -> None:
+        actual = table_factory().reorder_columns(column_names)
+        assert_tables_are_equal(actual, expected)
+
+    def test_should_not_mutate_receiver(
+        self,
+        table_factory: Callable[[], Table],
+        column_names: list[str],
+        expected: Table,  # noqa: ARG002
+    ) -> None:
+        original = table_factory()
+        original.reorder_columns(column_names)
+        assert_tables_are_equal(original, table_factory())
+
+
+def test_should_raise_if_column_does_not_exist() -> None:
+    with pytest.raises(ColumnNotFoundError):
+        Table({"a": [1], "b": [2]}).reorder_columns(["a", "c"])
+
+
+def test_should_raise_if_column_is_missing_from_list() -> None:
+    with pytest.raises(ValueError, match="exist in the table but were not listed"):
+        Table({"a": [1], "b": [2], "c": [3]}).reorder_columns(["a", "b"])
+
+
+def test_should_raise_if_column_name_is_duplicated() -> None:
+    with pytest.raises(DuplicateColumnError):
+        Table({"a": [1], "b": [2]}).reorder_columns(["a", "a", "b"])


### PR DESCRIPTION
This function is similar to Table.select_column, but also validates that all columns remain in the table.