### PR TITLE
feat: remove dangling type parameter of cell

### DIFF
--- a/src/portabellas/containers/_cell/_cell.py
+++ b/src/portabellas/containers/_cell/_cell.py
@@ -30,7 +30,7 @@ type ConvertibleToStringCell = str | Cell | None
 _UNKNOWN = DataTypes.Unknown()
 
 
-class Cell[T_co](ABC):
+class Cell(ABC):
     """
     A single value in a table.
 
@@ -93,7 +93,7 @@ class Cell[T_co](ABC):
         year: ConvertibleToIntCell,
         month: ConvertibleToIntCell,
         day: ConvertibleToIntCell,
-    ) -> Cell[date | None]:
+    ) -> Cell:
         """
         Create a cell with a date.
 
@@ -158,7 +158,7 @@ class Cell[T_co](ABC):
         *,
         microsecond: ConvertibleToIntCell = 0,
         time_zone: str | None = None,
-    ) -> Cell[datetime | None]:
+    ) -> Cell:
         """
         Create a cell with a datetime.
 
@@ -254,7 +254,7 @@ class Cell[T_co](ABC):
         seconds: ConvertibleToIntCell = 0,
         milliseconds: ConvertibleToIntCell = 0,
         microseconds: ConvertibleToIntCell = 0,
-    ) -> Cell[timedelta | None]:
+    ) -> Cell:
         """
         Create a cell with a duration.
 
@@ -335,7 +335,7 @@ class Cell[T_co](ABC):
         second: ConvertibleToIntCell,
         *,
         microsecond: ConvertibleToIntCell = 0,
-    ) -> Cell[time | None]:
+    ) -> Cell:
         """
         Create a cell with a time.
 
@@ -396,7 +396,7 @@ class Cell[T_co](ABC):
         )
 
     @staticmethod
-    def first_not_null[P](cells: list[Cell[P]]) -> Cell[P | None]:
+    def first_not_null(cells: list[Cell]) -> Cell:
         """
         Return the first cell that is not null or None if all cells are null.
 
@@ -437,47 +437,47 @@ class Cell[T_co](ABC):
     # "Boolean" operators (actually bitwise) -----------------------------------
 
     @abstractmethod
-    def __invert__(self) -> Cell[bool | None]: ...
+    def __invert__(self) -> Cell: ...
 
     @abstractmethod
-    def __and__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]: ...
+    def __and__(self, other: ConvertibleToBooleanCell) -> Cell: ...
 
     @abstractmethod
-    def __rand__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]: ...
+    def __rand__(self, other: ConvertibleToBooleanCell) -> Cell: ...
 
     @abstractmethod
-    def __or__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]: ...
+    def __or__(self, other: ConvertibleToBooleanCell) -> Cell: ...
 
     @abstractmethod
-    def __ror__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]: ...
+    def __ror__(self, other: ConvertibleToBooleanCell) -> Cell: ...
 
     @abstractmethod
-    def __xor__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]: ...
+    def __xor__(self, other: ConvertibleToBooleanCell) -> Cell: ...
 
     @abstractmethod
-    def __rxor__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]: ...
+    def __rxor__(self, other: ConvertibleToBooleanCell) -> Cell: ...
 
     # Comparison ---------------------------------------------------------------
 
     @abstractmethod
-    def __eq__(self, other: object) -> Cell[bool | None]:  # type: ignore[override]
+    def __eq__(self, other: object) -> Cell:  # type: ignore[override]
         ...
 
     @abstractmethod
-    def __ne__(self, other: object) -> Cell[bool | None]:  # type: ignore[override]
+    def __ne__(self, other: object) -> Cell:  # type: ignore[override]
         ...
 
     @abstractmethod
-    def __ge__(self, other: object) -> Cell[bool | None]: ...
+    def __ge__(self, other: object) -> Cell: ...
 
     @abstractmethod
-    def __gt__(self, other: object) -> Cell[bool | None]: ...
+    def __gt__(self, other: object) -> Cell: ...
 
     @abstractmethod
-    def __le__(self, other: object) -> Cell[bool | None]: ...
+    def __le__(self, other: object) -> Cell: ...
 
     @abstractmethod
-    def __lt__(self, other: object) -> Cell[bool | None]: ...
+    def __lt__(self, other: object) -> Cell: ...
 
     # Numeric operators --------------------------------------------------------
 
@@ -553,7 +553,7 @@ class Cell[T_co](ABC):
     # Boolean operations
     # ------------------------------------------------------------------------------------------------------------------
 
-    def not_(self) -> Cell[bool | None]:
+    def not_(self) -> Cell:
         """
         Negate a Boolean. This is equivalent to the `~` operator.
 
@@ -593,7 +593,7 @@ class Cell[T_co](ABC):
         """
         return self.__invert__()
 
-    def and_(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def and_(self, other: ConvertibleToBooleanCell) -> Cell:
         """
         Perform a Boolean AND operation. This is equivalent to the `&` operator.
 
@@ -638,7 +638,7 @@ class Cell[T_co](ABC):
         """
         return self.__and__(other)
 
-    def or_(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def or_(self, other: ConvertibleToBooleanCell) -> Cell:
         """
         Perform a Boolean OR operation. This is equivalent to the `|` operator.
 
@@ -682,7 +682,7 @@ class Cell[T_co](ABC):
         """
         return self.__or__(other)
 
-    def xor(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def xor(self, other: ConvertibleToBooleanCell) -> Cell:
         """
         Perform a Boolean XOR operation. This is equivalent to the `^` operator.
 
@@ -1029,7 +1029,7 @@ class Cell[T_co](ABC):
         other: object,
         *,
         propagate_nulls: bool = False,
-    ) -> Cell[bool | None]:
+    ) -> Cell:
         """
         Check if equal to a value. The default behavior is equivalent to the `==` operator.
 
@@ -1097,7 +1097,7 @@ class Cell[T_co](ABC):
         other: object,
         *,
         propagate_nulls: bool = False,
-    ) -> Cell[bool | None]:
+    ) -> Cell:
         """
         Check if not equal to a value. The default behavior is equivalent to the `!=` operator.
 
@@ -1159,7 +1159,7 @@ class Cell[T_co](ABC):
         +-------+
         """
 
-    def ge(self, other: object) -> Cell[bool | None]:
+    def ge(self, other: object) -> Cell:
         """
         Check if greater than or equal to a value. This is equivalent to the `>=` operator.
 
@@ -1201,7 +1201,7 @@ class Cell[T_co](ABC):
         """
         return self.__ge__(other)
 
-    def gt(self, other: object) -> Cell[bool | None]:
+    def gt(self, other: object) -> Cell:
         """
         Check if greater than a value. This is equivalent to the `>` operator.
 
@@ -1243,7 +1243,7 @@ class Cell[T_co](ABC):
         """
         return self.__gt__(other)
 
-    def le(self, other: object) -> Cell[bool | None]:
+    def le(self, other: object) -> Cell:
         """
         Check if less than or equal to a value. This is equivalent to the `<=` operator.
 
@@ -1285,7 +1285,7 @@ class Cell[T_co](ABC):
         """
         return self.__le__(other)
 
-    def lt(self, other: object) -> Cell[bool | None]:
+    def lt(self, other: object) -> Cell:
         """
         Check if less than a value. This is equivalent to the `<` operator.
 

--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 _UNKNOWN = DataTypes.Unknown()
 
 
-class ExprCell[T](Cell[T]):
+class ExprCell(Cell):
     """
     A single value in a table.
 
@@ -46,56 +46,56 @@ class ExprCell[T](Cell[T]):
 
     # "Boolean" operators (actually bitwise) -----------------------------------
 
-    def __invert__(self) -> Cell[bool | None]:
+    def __invert__(self) -> Cell:
         return ExprCell(self._expression.cast(pl.Boolean).__invert__())
 
-    def __and__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def __and__(self, other: ConvertibleToBooleanCell) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__and__(other_expr))
 
-    def __rand__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def __rand__(self, other: ConvertibleToBooleanCell) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rand__(other_expr))
 
-    def __or__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def __or__(self, other: ConvertibleToBooleanCell) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__or__(other_expr))
 
-    def __ror__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def __ror__(self, other: ConvertibleToBooleanCell) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__ror__(other_expr))
 
-    def __xor__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def __xor__(self, other: ConvertibleToBooleanCell) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__xor__(other_expr))
 
-    def __rxor__(self, other: ConvertibleToBooleanCell) -> Cell[bool | None]:
+    def __rxor__(self, other: ConvertibleToBooleanCell) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rxor__(other_expr))
 
     # Comparison ---------------------------------------------------------------
 
-    def __eq__(self, other: object) -> Cell[bool | None]:  # type: ignore[override]
+    def __eq__(self, other: object) -> Cell:  # type: ignore[override]
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.eq_missing(other_expr))
 
-    def __ge__(self, other: object) -> Cell[bool | None]:
+    def __ge__(self, other: object) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__ge__(other_expr))
 
-    def __gt__(self, other: object) -> Cell[bool | None]:
+    def __gt__(self, other: object) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__gt__(other_expr))
 
-    def __le__(self, other: object) -> Cell[bool | None]:
+    def __le__(self, other: object) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__le__(other_expr))
 
-    def __lt__(self, other: object) -> Cell[bool | None]:
+    def __lt__(self, other: object) -> Cell:
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__lt__(other_expr))
 
-    def __ne__(self, other: object) -> Cell[bool | None]:  # type: ignore[override]
+    def __ne__(self, other: object) -> Cell:  # type: ignore[override]
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.ne_missing(other_expr))
 
@@ -186,7 +186,7 @@ class ExprCell[T](Cell[T]):
     # Comparison operations
     # ------------------------------------------------------------------------------------------------------------------
 
-    def eq(self, other: object, *, propagate_nulls: bool = False) -> Cell[bool | None]:
+    def eq(self, other: object, *, propagate_nulls: bool = False) -> Cell:
         other_expr = _to_polars_expression(other)
 
         if propagate_nulls:
@@ -194,7 +194,7 @@ class ExprCell[T](Cell[T]):
         else:
             return ExprCell(self._expression.eq_missing(other_expr))
 
-    def neq(self, other: object, *, propagate_nulls: bool = False) -> Cell[bool | None]:
+    def neq(self, other: object, *, propagate_nulls: bool = False) -> Cell:
         other_expr = _to_polars_expression(other)
 
         if propagate_nulls:

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -356,7 +356,7 @@ class Column[T_co](Sequence[T_co]):
 
     def map(
         self,
-        mapper: Callable[[Cell[T_co]], Cell],
+        mapper: Callable[[Cell], Cell],
     ) -> Column:
         """
         Transform the values in the column and return the result as a new column.
@@ -400,7 +400,7 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def all(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: Literal[True] = ...,
     ) -> bool: ...
@@ -408,14 +408,14 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def all(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool,
     ) -> bool | None: ...
 
     def all(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool = True,
     ) -> bool | None:
@@ -477,7 +477,7 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def any(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: Literal[True] = ...,
     ) -> bool: ...
@@ -485,14 +485,14 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def any(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool,
     ) -> bool | None: ...
 
     def any(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool = True,
     ) -> bool | None:
@@ -554,7 +554,7 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def count_if(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: Literal[True] = ...,
     ) -> int: ...
@@ -562,14 +562,14 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def count_if(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool,
     ) -> int | None: ...
 
     def count_if(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool = True,
     ) -> int | None:
@@ -622,7 +622,7 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def none(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: Literal[True] = ...,
     ) -> bool: ...
@@ -630,14 +630,14 @@ class Column[T_co](Sequence[T_co]):
     @overload
     def none(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool,
     ) -> bool | None: ...
 
     def none(
         self,
-        predicate: Callable[[Cell[T_co]], Cell[bool | None]],
+        predicate: Callable[[Cell], Cell],
         *,
         ignore_nulls: bool = True,
     ) -> bool | None:

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1098,7 +1098,7 @@ class Table:
     @overload
     def count_rows_if(
         self,
-        predicate: Callable[[Row], Cell[bool | None]],
+        predicate: Callable[[Row], Cell],
         *,
         ignore_nulls: Literal[True] = ...,
     ) -> int: ...
@@ -1106,14 +1106,14 @@ class Table:
     @overload
     def count_rows_if(
         self,
-        predicate: Callable[[Row], Cell[bool | None]],
+        predicate: Callable[[Row], Cell],
         *,
         ignore_nulls: bool,
     ) -> int | None: ...
 
     def count_rows_if(
         self,
-        predicate: Callable[[Row], Cell[bool | None]],
+        predicate: Callable[[Row], Cell],
         *,
         ignore_nulls: bool = True,
     ) -> int | None:
@@ -1161,7 +1161,7 @@ class Table:
 
     def filter_rows(
         self,
-        predicate: Callable[[Row], Cell[bool | None]],
+        predicate: Callable[[Row], Cell],
     ) -> Table:
         """
         Keep only rows that satisfy a condition and return the result as a new table.
@@ -1228,7 +1228,7 @@ class Table:
 
     def remove_rows(
         self,
-        predicate: Callable[[Row], Cell[bool | None]],
+        predicate: Callable[[Row], Cell],
     ) -> Table:
         """
         Remove rows that satisfy a condition and return the result as a new table.

--- a/src/portabellas/query/_datetime_operations/_datetime_operations.py
+++ b/src/portabellas/query/_datetime_operations/_datetime_operations.py
@@ -4,9 +4,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from datetime import date as python_date
-    from datetime import time as python_time
-
     from portabellas.containers import Cell
     from portabellas.containers._cell import ConvertibleToIntCell
 
@@ -34,7 +31,7 @@ class DatetimeOperations(ABC):
     """
 
     @abstractmethod
-    def century(self) -> Cell[int | None]:
+    def century(self) -> Cell:
         """
         Extract the century from a datetime or date.
 
@@ -78,7 +75,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def date(self) -> Cell[python_date | None]:
+    def date(self) -> Cell:
         """
         Extract the date from a datetime.
 
@@ -105,7 +102,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def day(self) -> Cell[int | None]:
+    def day(self) -> Cell:
         """
         Extract the day from a datetime or date.
 
@@ -144,7 +141,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def day_of_week(self) -> Cell[int | None]:
+    def day_of_week(self) -> Cell:
         """
         Extract the day of the week from a datetime or date as defined by ISO 8601.
 
@@ -185,7 +182,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def day_of_year(self) -> Cell[int | None]:
+    def day_of_year(self) -> Cell:
         """
         Extract the day of the year from a datetime or date.
 
@@ -228,7 +225,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def hour(self) -> Cell[int | None]:
+    def hour(self) -> Cell:
         """
         Extract the hour from a datetime or time.
 
@@ -267,7 +264,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def microsecond(self) -> Cell[int | None]:
+    def microsecond(self) -> Cell:
         """
         Extract the microsecond from a datetime or time.
 
@@ -306,7 +303,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def millennium(self) -> Cell[int | None]:
+    def millennium(self) -> Cell:
         """
         Extract the millennium from a datetime or date.
 
@@ -350,7 +347,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def millisecond(self) -> Cell[int | None]:
+    def millisecond(self) -> Cell:
         """
         Extract the millisecond from a datetime or time.
 
@@ -389,7 +386,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def minute(self) -> Cell[int | None]:
+    def minute(self) -> Cell:
         """
         Extract the minute from a datetime or time.
 
@@ -428,7 +425,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def month(self) -> Cell[int | None]:
+    def month(self) -> Cell:
         """
         Extract the month from a datetime or date.
 
@@ -467,7 +464,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def quarter(self) -> Cell[int | None]:
+    def quarter(self) -> Cell:
         """
         Extract the quarter from a datetime or date.
 
@@ -515,7 +512,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def second(self) -> Cell[int | None]:
+    def second(self) -> Cell:
         """
         Extract the second from a datetime or time.
 
@@ -554,7 +551,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def time(self) -> Cell[python_time | None]:
+    def time(self) -> Cell:
         """
         Extract the time from a datetime.
 
@@ -581,7 +578,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def week(self) -> Cell[int | None]:
+    def week(self) -> Cell:
         """
         Extract the ISO 8601 week number from a datetime or date.
 
@@ -626,7 +623,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def year(self) -> Cell[int | None]:
+    def year(self) -> Cell:
         """
         Extract the year from a datetime or date.
 
@@ -665,7 +662,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def is_in_leap_year(self) -> Cell[bool | None]:
+    def is_in_leap_year(self) -> Cell:
         """
         Check a datetime or date is in a leap year.
 
@@ -771,7 +768,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def to_string(self, *, format: str = "iso") -> Cell[str | None]:  # noqa: A002
+    def to_string(self, *, format: str = "iso") -> Cell:  # noqa: A002
         r"""
         Convert a datetime, date, or time to a string.
 
@@ -897,7 +894,7 @@ class DatetimeOperations(ABC):
         """
 
     @abstractmethod
-    def unix_timestamp(self, *, unit: Literal["s", "ms", "us"] = "s") -> Cell[int | None]:
+    def unix_timestamp(self, *, unit: Literal["s", "ms", "us"] = "s") -> Cell:
         """
         Get the Unix timestamp from a datetime.
 

--- a/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
+++ b/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
@@ -97,7 +97,7 @@ class ExprDatetimeOperations(DatetimeOperations):
             ),
         )
 
-    def to_string(self, *, format: str = "iso") -> Cell[str | None]:  # noqa: A002
+    def to_string(self, *, format: str = "iso") -> Cell:  # noqa: A002
         if format == "iso":
             polars_format = "iso:strict"
         else:
@@ -105,7 +105,7 @@ class ExprDatetimeOperations(DatetimeOperations):
 
         return _expr_cell(self._expression.dt.to_string(format=polars_format))
 
-    def unix_timestamp(self, *, unit: Literal["s", "ms", "us"] = "s") -> Cell[int | None]:
+    def unix_timestamp(self, *, unit: Literal["s", "ms", "us"] = "s") -> Cell:
         return _expr_cell(self._expression.dt.epoch(time_unit=unit))
 
 

--- a/src/portabellas/query/_duration_operations/_duration_operations.py
+++ b/src/portabellas/query/_duration_operations/_duration_operations.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
-    from datetime import timedelta
-
     from portabellas.containers import Cell
 
 
@@ -33,7 +31,7 @@ class DurationOperations(ABC):
     """
 
     @abstractmethod
-    def abs(self) -> Cell[timedelta | None]:
+    def abs(self) -> Cell:
         """
         Get the absolute value of the duration.
 
@@ -60,7 +58,7 @@ class DurationOperations(ABC):
         """
 
     @abstractmethod
-    def full_weeks(self) -> Cell[int | None]:
+    def full_weeks(self) -> Cell:
         """
         Get the number of full weeks in the duration. The result is rounded toward zero.
 
@@ -87,7 +85,7 @@ class DurationOperations(ABC):
         """
 
     @abstractmethod
-    def full_days(self) -> Cell[int | None]:
+    def full_days(self) -> Cell:
         """
         Get the number of full days in the duration. The result is rounded toward zero.
 
@@ -114,7 +112,7 @@ class DurationOperations(ABC):
         """
 
     @abstractmethod
-    def full_hours(self) -> Cell[int | None]:
+    def full_hours(self) -> Cell:
         """
         Get the number of full hours in the duration. The result is rounded toward zero.
 
@@ -141,7 +139,7 @@ class DurationOperations(ABC):
         """
 
     @abstractmethod
-    def full_minutes(self) -> Cell[int | None]:
+    def full_minutes(self) -> Cell:
         """
         Get the number of full minutes in the duration. The result is rounded toward zero.
 
@@ -168,7 +166,7 @@ class DurationOperations(ABC):
         """
 
     @abstractmethod
-    def full_seconds(self) -> Cell[int | None]:
+    def full_seconds(self) -> Cell:
         """
         Get the number of full seconds in the duration. The result is rounded toward zero.
 
@@ -195,7 +193,7 @@ class DurationOperations(ABC):
         """
 
     @abstractmethod
-    def full_milliseconds(self) -> Cell[int | None]:
+    def full_milliseconds(self) -> Cell:
         """
         Get the number of full milliseconds in the duration. The result is rounded toward zero.
 
@@ -222,7 +220,7 @@ class DurationOperations(ABC):
         """
 
     @abstractmethod
-    def full_microseconds(self) -> Cell[int | None]:
+    def full_microseconds(self) -> Cell:
         """
         Get the number of full microseconds in the duration. The result is rounded toward zero.
 
@@ -256,7 +254,7 @@ class DurationOperations(ABC):
         self,
         *,
         format: Literal["iso", "pretty"] = "iso",  # noqa: A002
-    ) -> Cell[str | None]:
+    ) -> Cell:
         """
         Convert the duration to a string.
 

--- a/src/portabellas/query/_list_operations/_list_operations.py
+++ b/src/portabellas/query/_list_operations/_list_operations.py
@@ -16,7 +16,7 @@ class ListOperations(ABC):
     """
 
     @abstractmethod
-    def contains(self, item: ConvertibleToCell) -> Cell[bool | None]:
+    def contains(self, item: ConvertibleToCell) -> Cell:
         """
         Check if the list contains the given item.
 
@@ -114,7 +114,7 @@ class ListOperations(ABC):
         """
 
     @abstractmethod
-    def join(self, separator: ConvertibleToStringCell) -> Cell[str | None]:
+    def join(self, separator: ConvertibleToStringCell) -> Cell:
         """
         Join all elements in the list into a string, separated by the given separator.
 
@@ -169,7 +169,7 @@ class ListOperations(ABC):
         """
 
     @abstractmethod
-    def length(self) -> Cell[int | None]:
+    def length(self) -> Cell:
         """
         Get the number of elements in the list.
 

--- a/src/portabellas/query/_string_operations/_string_operations.py
+++ b/src/portabellas/query/_string_operations/_string_operations.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from datetime import date, datetime, time
-
     from portabellas.containers import Cell
     from portabellas.containers._cell import ConvertibleToIntCell, ConvertibleToStringCell
 
@@ -33,7 +31,7 @@ class StringOperations(ABC):
     """
 
     @abstractmethod
-    def contains(self, substring: ConvertibleToStringCell) -> Cell[bool | None]:
+    def contains(self, substring: ConvertibleToStringCell) -> Cell:
         """
         Check if the string contains the substring.
 
@@ -64,7 +62,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def ends_with(self, suffix: ConvertibleToStringCell) -> Cell[bool | None]:
+    def ends_with(self, suffix: ConvertibleToStringCell) -> Cell:
         """
         Check if the string ends with the suffix.
 
@@ -95,7 +93,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def index_of(self, substring: ConvertibleToStringCell) -> Cell[int | None]:
+    def index_of(self, substring: ConvertibleToStringCell) -> Cell:
         """
         Get the index of the first occurrence of the substring.
 
@@ -126,7 +124,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def length(self, *, optimize_for_ascii: bool = False) -> Cell[int | None]:
+    def length(self, *, optimize_for_ascii: bool = False) -> Cell:
         """
         Get the number of characters.
 
@@ -159,7 +157,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def pad_end(self, length: int, *, character: str = " ") -> Cell[str | None]:
+    def pad_end(self, length: int, *, character: str = " ") -> Cell:
         """
         Pad the end of the string with the given character until it has the given length.
 
@@ -211,7 +209,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def pad_start(self, length: int, *, character: str = " ") -> Cell[str | None]:
+    def pad_start(self, length: int, *, character: str = " ") -> Cell:
         """
         Pad the start of the string with the given character until it has the given length.
 
@@ -263,7 +261,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def remove_prefix(self, prefix: ConvertibleToStringCell) -> Cell[str | None]:
+    def remove_prefix(self, prefix: ConvertibleToStringCell) -> Cell:
         """
         Remove a prefix from the string. Strings without the prefix are not changed.
 
@@ -294,7 +292,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def remove_suffix(self, suffix: ConvertibleToStringCell) -> Cell[str | None]:
+    def remove_suffix(self, suffix: ConvertibleToStringCell) -> Cell:
         """
         Remove a suffix from the string. Strings without the suffix are not changed.
 
@@ -325,7 +323,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def repeat(self, count: ConvertibleToIntCell) -> Cell[str | None]:
+    def repeat(self, count: ConvertibleToIntCell) -> Cell:
         """
         Repeat the string a number of times.
 
@@ -361,7 +359,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def replace_all(self, old: ConvertibleToStringCell, new: ConvertibleToStringCell) -> Cell[str | None]:
+    def replace_all(self, old: ConvertibleToStringCell, new: ConvertibleToStringCell) -> Cell:
         """
         Replace all occurrences of the old substring with the new substring.
 
@@ -394,7 +392,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def reverse(self) -> Cell[str | None]:
+    def reverse(self) -> Cell:
         """
         Reverse the string.
 
@@ -425,7 +423,7 @@ class StringOperations(ABC):
         *,
         start: ConvertibleToIntCell = 0,
         length: ConvertibleToIntCell = None,
-    ) -> Cell[str | None]:
+    ) -> Cell:
         """
         Get a slice of the string.
 
@@ -476,7 +474,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def starts_with(self, prefix: ConvertibleToStringCell) -> Cell[bool | None]:
+    def starts_with(self, prefix: ConvertibleToStringCell) -> Cell:
         """
         Check if the string starts with the prefix.
 
@@ -507,7 +505,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def strip(self, *, characters: ConvertibleToStringCell = None) -> Cell[str | None]:
+    def strip(self, *, characters: ConvertibleToStringCell = None) -> Cell:
         """
         Remove leading and trailing characters.
 
@@ -549,7 +547,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def strip_end(self, *, characters: ConvertibleToStringCell = None) -> Cell[str | None]:
+    def strip_end(self, *, characters: ConvertibleToStringCell = None) -> Cell:
         """
         Remove trailing characters.
 
@@ -591,7 +589,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def strip_start(self, *, characters: ConvertibleToStringCell = None) -> Cell[str | None]:
+    def strip_start(self, *, characters: ConvertibleToStringCell = None) -> Cell:
         """
         Remove leading characters.
 
@@ -633,7 +631,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def to_date(self, *, format: str | None = "iso") -> Cell[date | None]:  # noqa: A002
+    def to_date(self, *, format: str | None = "iso") -> Cell:  # noqa: A002
         r"""
         Convert a string to a date.
 
@@ -712,7 +710,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def to_datetime(self, *, format: str | None = "iso") -> Cell[datetime | None]:  # noqa: A002
+    def to_datetime(self, *, format: str | None = "iso") -> Cell:  # noqa: A002
         r"""
         Convert a string to a datetime.
 
@@ -814,7 +812,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def to_float(self) -> Cell[float | None]:
+    def to_float(self) -> Cell:
         """
         Convert the string to a float.
 
@@ -841,7 +839,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def to_int(self, *, base: ConvertibleToIntCell = 10) -> Cell[int | None]:
+    def to_int(self, *, base: ConvertibleToIntCell = 10) -> Cell:
         """
         Convert the string to an integer.
 
@@ -886,7 +884,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def to_lowercase(self) -> Cell[str | None]:
+    def to_lowercase(self) -> Cell:
         """
         Convert the string to lowercase.
 
@@ -912,7 +910,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def to_time(self, *, format: str | None = "iso") -> Cell[time | None]:  # noqa: A002
+    def to_time(self, *, format: str | None = "iso") -> Cell:  # noqa: A002
         r"""
         Convert a string to a time.
 
@@ -990,7 +988,7 @@ class StringOperations(ABC):
         """
 
     @abstractmethod
-    def to_uppercase(self) -> Cell[str | None]:
+    def to_uppercase(self) -> Cell:
         """
         Convert the string to uppercase.
 

--- a/src/portabellas/query/_struct_operations/_struct_operations.py
+++ b/src/portabellas/query/_struct_operations/_struct_operations.py
@@ -151,7 +151,7 @@ class StructOperations(ABC):
         """
 
     @abstractmethod
-    def to_json(self) -> Cell[str | None]:
+    def to_json(self) -> Cell:
         """
         Convert the struct to a JSON string.
 

--- a/tests/portabellas/containers/_table/test_filter_rows.py
+++ b/tests/portabellas/containers/_table/test_filter_rows.py
@@ -52,7 +52,7 @@ class TestHappyPath:
     def test_should_filter_rows(
         self,
         table_factory: Callable[[], Table],
-        predicate: Callable[[Row], Cell[bool]],
+        predicate: Callable[[Row], Cell],
         expected: Table,
     ) -> None:
         actual = table_factory().filter_rows(predicate)
@@ -61,7 +61,7 @@ class TestHappyPath:
     def test_should_not_mutate_receiver(
         self,
         table_factory: Callable[[], Table],
-        predicate: Callable[[Row], Cell[bool]],
+        predicate: Callable[[Row], Cell],
         expected: Table,  # noqa: ARG002
     ) -> None:
         original = table_factory()

--- a/tests/portabellas/containers/_table/test_remove_rows.py
+++ b/tests/portabellas/containers/_table/test_remove_rows.py
@@ -52,7 +52,7 @@ class TestHappyPath:
     def test_should_remove_rows(
         self,
         table_factory: Callable[[], Table],
-        predicate: Callable[[Row], Cell[bool]],
+        predicate: Callable[[Row], Cell],
         expected: Table,
     ) -> None:
         actual = table_factory().remove_rows(predicate)
@@ -61,7 +61,7 @@ class TestHappyPath:
     def test_should_not_mutate_receiver(
         self,
         table_factory: Callable[[], Table],
-        predicate: Callable[[Row], Cell[bool]],
+        predicate: Callable[[Row], Cell],
         expected: Table,  # noqa: ARG002
     ) -> None:
         original = table_factory()


### PR DESCRIPTION
It's not possible to statically infer the type parameter in general, so we'd get tons of false positive errors from static type checkers.