### PR TITLE
feat(query): add cell.list[index] bracket-access shorthand

### DIFF
--- a/src/portabellas/query/_list_operations/_expr_list_operations.py
+++ b/src/portabellas/query/_list_operations/_expr_list_operations.py
@@ -19,9 +19,20 @@ _UINT32 = DataTypes.UInt32()
 
 
 class ExprListOperations(ListOperations):
+    # ------------------------------------------------------------------------------------------------------------------
+    # Dunder methods
+    # ------------------------------------------------------------------------------------------------------------------
+
     def __init__(self, expression: pl.Expr, type: DataType) -> None:  # noqa: A002
         self._expression: pl.Expr = expression
         self._type: DataType = type
+
+    def __getitem__(self, index: ConvertibleToIntCell) -> Cell:
+        return self.get(index)
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Named methods
+    # ------------------------------------------------------------------------------------------------------------------
 
     def contains(self, item: ConvertibleToCell) -> Cell:
         item_expr = _to_polars_expression(item)

--- a/src/portabellas/query/_list_operations/_list_operations.py
+++ b/src/portabellas/query/_list_operations/_list_operations.py
@@ -15,6 +15,17 @@ class ListOperations(ABC):
     This class cannot be instantiated directly. It can only be accessed using the `list` attribute of a cell.
     """
 
+    # ------------------------------------------------------------------------------------------------------------------
+    # Dunder methods
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def __getitem__(self, index: ConvertibleToIntCell) -> Cell:
+        return self.get(index)
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Named methods
+    # ------------------------------------------------------------------------------------------------------------------
+
     @abstractmethod
     def contains(self, item: ConvertibleToCell) -> Cell:
         """

--- a/tests/portabellas/query/_list_operations/test_getitem.py
+++ b/tests/portabellas/query/_list_operations/test_getitem.py
@@ -1,0 +1,36 @@
+import pytest
+
+from portabellas.containers import Cell
+from portabellas.typing import DataTypes
+from tests.helpers import assert_cell_operation_works
+
+
+@pytest.mark.parametrize(
+    ("value", "index", "expected"),
+    [
+        pytest.param([1, 2, 3], 0, 1, id="first element"),
+        pytest.param([1, 2, 3], 2, 3, id="last element"),
+        pytest.param([1, 2, 3], 5, None, id="positive out of bounds"),
+        pytest.param([], 0, None, id="empty list"),
+        pytest.param(None, 0, None, id="None list"),
+        pytest.param([1, 2, 3], -1, 3, id="negative index last element"),
+        pytest.param([1, 2, 3], -2, 2, id="negative index second to last element"),
+        pytest.param([1, 2, 3], -4, None, id="negative out of bounds"),
+    ],
+)
+class TestShouldGetElementByBracketAccess:
+    def test_plain_arguments(self, value: list | None, index: int, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value,
+            lambda cell: cell.list[index],
+            expected,
+            type_=DataTypes.List(DataTypes.Int64()),
+        )
+
+    def test_arguments_wrapped_in_cell(self, value: list | None, index: int, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value,
+            lambda cell: cell.list[Cell.constant(index)],
+            expected,
+            type_=DataTypes.List(DataTypes.Int64()),
+        )


### PR DESCRIPTION
Closes #145

### Summary of Changes

- Enable bracket-access on list cells (`cell.list[0]`) as a shorthand for `cell.list.get(0)`, matching the existing `cell.struct["name"]` pattern.
