### PR TITLE
feat(query): add type inference for list inner-type extraction methods

### DIFF
--- a/src/portabellas/containers/_cell/_cell.py
+++ b/src/portabellas/containers/_cell/_cell.py
@@ -1519,7 +1519,7 @@ class Cell(ABC):
         """The type of this cell."""
 
 
-def _expr_cell(expression: pl.Expr, *, type: DataType = _UNKNOWN) -> Cell:  # noqa: A002
+def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002
     from ._expr_cell import ExprCell  # circular import  # noqa: PLC0415
 
     return ExprCell(expression, type=type)

--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     )
 
 _BOOLEAN = DataTypes.Boolean()
-_UNKNOWN = DataTypes.Unknown()
 
 
 class ExprCell(Cell):
@@ -42,7 +41,7 @@ class ExprCell(Cell):
     # Dunder methods
     # ------------------------------------------------------------------------------------------------------------------
 
-    def __init__(self, expression: pl.Expr, *, type: DataType = _UNKNOWN) -> None:  # noqa: A002
+    def __init__(self, expression: pl.Expr, *, type: DataType) -> None:  # noqa: A002
         self._expression: pl.Expr = expression
         self.__type: DataType = type
 

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1076,11 +1076,16 @@ class Table:
         parameter_count = mapper.__code__.co_argcount
         if parameter_count == 1:
             one_arg_mapper: Callable[[Cell], Cell] = mapper  # type: ignore[assignment]
-            expressions = [one_arg_mapper(_expr_cell(pl.col(name)))._polars_expression.alias(name) for name in selector]
+            expressions = [
+                one_arg_mapper(_expr_cell(pl.col(name), type=self.get_column_type(name)))._polars_expression.alias(name)
+                for name in selector
+            ]
         else:
             two_arg_mapper: Callable[[Cell, Row], Cell] = mapper  # type: ignore[assignment]
             expressions = [
-                two_arg_mapper(_expr_cell(pl.col(name)), ExprRow(self))._polars_expression.alias(name)
+                two_arg_mapper(
+                    _expr_cell(pl.col(name), type=self.get_column_type(name)), ExprRow(self)
+                )._polars_expression.alias(name)
                 for name in selector
             ]
 

--- a/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
+++ b/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
@@ -23,7 +23,6 @@ _INT32 = DataTypes.Int32()
 _INT64 = DataTypes.Int64()
 _STRING = DataTypes.String()
 _TIME = DataTypes.Time()
-_UNKNOWN = DataTypes.Unknown()
 
 
 class ExprDatetimeOperations(DatetimeOperations):
@@ -118,7 +117,7 @@ class ExprDatetimeOperations(DatetimeOperations):
         return _expr_cell(self._expression.dt.epoch(time_unit=unit), type=_INT64)
 
 
-def _expr_cell(expression: pl.Expr, *, type: DataType = _UNKNOWN) -> Cell:  # noqa: A002
+def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002
     from portabellas.containers._cell._expr_cell import ExprCell  # circular import  # noqa: PLC0415
 
     return ExprCell(expression, type=type)

--- a/src/portabellas/query/_duration_operations/_expr_duration_operations.py
+++ b/src/portabellas/query/_duration_operations/_expr_duration_operations.py
@@ -11,7 +11,6 @@ from ._duration_operations import DurationOperations
 if TYPE_CHECKING:
     from portabellas.containers import Cell
 
-_UNKNOWN = DataTypes.Unknown()
 _INT64 = DataTypes.Int64()
 _STRING = DataTypes.String()
 
@@ -55,7 +54,7 @@ class ExprDurationOperations(DurationOperations):
         return _expr_cell(self._expression.dt.to_string(polars_format), type=_STRING)
 
 
-def _expr_cell(expression: pl.Expr, *, type: DataType = _UNKNOWN) -> Cell:  # noqa: A002
+def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002
     from portabellas.containers._cell._expr_cell import ExprCell  # circular import  # noqa: PLC0415
 
     return ExprCell(expression, type=type)

--- a/src/portabellas/query/_list_operations/_expr_list_operations.py
+++ b/src/portabellas/query/_list_operations/_expr_list_operations.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from portabellas.containers._cell._cell import Cell
 from portabellas.typing import DataType, DataTypes
+from portabellas.typing._type_inference import infer_operation_type
 
 from ._list_operations import ListOperations
 
@@ -16,6 +17,12 @@ _UNKNOWN = DataTypes.Unknown()
 _BOOLEAN = DataTypes.Boolean()
 _STRING = DataTypes.String()
 _UINT32 = DataTypes.UInt32()
+
+
+def _inner_type_if_list(type: DataType) -> DataType:  # noqa: A002
+    if isinstance(type, DataTypes.List):
+        return type.inner
+    return _UNKNOWN
 
 
 class ExprListOperations(ListOperations):
@@ -39,27 +46,27 @@ class ExprListOperations(ListOperations):
         return _expr_cell(self._expression.list.contains(item_expr), type=_BOOLEAN)
 
     def first(self) -> Cell:
-        return _expr_cell(self._expression.list.first(), type=_UNKNOWN)
+        return _expr_cell(self._expression.list.first(), type=_inner_type_if_list(self._type))
 
     def get(self, index: ConvertibleToIntCell) -> Cell:
         index_expr = _to_int_expression(index)
-        return _expr_cell(self._expression.list.get(index_expr, null_on_oob=True), type=_UNKNOWN)
+        return _expr_cell(self._expression.list.get(index_expr, null_on_oob=True), type=_inner_type_if_list(self._type))
 
     def join(self, separator: ConvertibleToStringCell) -> Cell:
         separator_expr = _to_string_expression(separator)
         return _expr_cell(self._expression.list.join(separator_expr), type=_STRING)
 
     def last(self) -> Cell:
-        return _expr_cell(self._expression.list.last(), type=_UNKNOWN)
+        return _expr_cell(self._expression.list.last(), type=_inner_type_if_list(self._type))
 
     def length(self) -> Cell:
         return _expr_cell(self._expression.list.len(), type=_UINT32)
 
     def max(self) -> Cell:
-        return _expr_cell(self._expression.list.max(), type=_UNKNOWN)
+        return _expr_cell(self._expression.list.max(), type=_inner_type_if_list(self._type))
 
     def min(self) -> Cell:
-        return _expr_cell(self._expression.list.min(), type=_UNKNOWN)
+        return _expr_cell(self._expression.list.min(), type=_inner_type_if_list(self._type))
 
     def reverse(self) -> Cell:
         return _expr_cell(self._expression.list.reverse(), type=self._type)
@@ -68,7 +75,12 @@ class ExprListOperations(ListOperations):
         return _expr_cell(self._expression.list.sort(descending=descending), type=self._type)
 
     def sum(self) -> Cell:
-        return _expr_cell(self._expression.list.sum(), type=_UNKNOWN)
+        result_type = (
+            infer_operation_type(lambda a: a.list.sum(), self._type)
+            if isinstance(self._type, DataTypes.List)
+            else _UNKNOWN
+        )
+        return _expr_cell(self._expression.list.sum(), type=result_type)
 
 
 def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002

--- a/src/portabellas/query/_list_operations/_expr_list_operations.py
+++ b/src/portabellas/query/_list_operations/_expr_list_operations.py
@@ -19,12 +19,6 @@ _STRING = DataTypes.String()
 _UINT32 = DataTypes.UInt32()
 
 
-def _inner_type_if_list(type: DataType) -> DataType:  # noqa: A002
-    if isinstance(type, DataTypes.List):
-        return type.inner
-    return _UNKNOWN
-
-
 class ExprListOperations(ListOperations):
     # ------------------------------------------------------------------------------------------------------------------
     # Dunder methods
@@ -75,11 +69,7 @@ class ExprListOperations(ListOperations):
         return _expr_cell(self._expression.list.sort(descending=descending), type=self._type)
 
     def sum(self) -> Cell:
-        result_type = (
-            infer_operation_type(lambda a: a.list.sum(), self._type)
-            if isinstance(self._type, DataTypes.List)
-            else _UNKNOWN
-        )
+        result_type = infer_operation_type(lambda a: a.list.sum(), self._type)
         return _expr_cell(self._expression.list.sum(), type=result_type)
 
 
@@ -109,3 +99,8 @@ def _to_string_expression(value: ConvertibleToStringCell) -> pl.Expr:
     if value is None:
         return pl.lit(value, dtype=pl.Utf8)
     return pl.lit(value)
+
+def _inner_type_if_list(type: DataType) -> DataType:  # noqa: A002
+    if isinstance(type, DataTypes.List):
+        return type.inner
+    return _UNKNOWN

--- a/src/portabellas/query/_list_operations/_expr_list_operations.py
+++ b/src/portabellas/query/_list_operations/_expr_list_operations.py
@@ -39,27 +39,27 @@ class ExprListOperations(ListOperations):
         return _expr_cell(self._expression.list.contains(item_expr), type=_BOOLEAN)
 
     def first(self) -> Cell:
-        return _expr_cell(self._expression.list.first())
+        return _expr_cell(self._expression.list.first(), type=_UNKNOWN)
 
     def get(self, index: ConvertibleToIntCell) -> Cell:
         index_expr = _to_int_expression(index)
-        return _expr_cell(self._expression.list.get(index_expr, null_on_oob=True))
+        return _expr_cell(self._expression.list.get(index_expr, null_on_oob=True), type=_UNKNOWN)
 
     def join(self, separator: ConvertibleToStringCell) -> Cell:
         separator_expr = _to_string_expression(separator)
         return _expr_cell(self._expression.list.join(separator_expr), type=_STRING)
 
     def last(self) -> Cell:
-        return _expr_cell(self._expression.list.last())
+        return _expr_cell(self._expression.list.last(), type=_UNKNOWN)
 
     def length(self) -> Cell:
         return _expr_cell(self._expression.list.len(), type=_UINT32)
 
     def max(self) -> Cell:
-        return _expr_cell(self._expression.list.max())
+        return _expr_cell(self._expression.list.max(), type=_UNKNOWN)
 
     def min(self) -> Cell:
-        return _expr_cell(self._expression.list.min())
+        return _expr_cell(self._expression.list.min(), type=_UNKNOWN)
 
     def reverse(self) -> Cell:
         return _expr_cell(self._expression.list.reverse(), type=self._type)
@@ -68,10 +68,10 @@ class ExprListOperations(ListOperations):
         return _expr_cell(self._expression.list.sort(descending=descending), type=self._type)
 
     def sum(self) -> Cell:
-        return _expr_cell(self._expression.list.sum())
+        return _expr_cell(self._expression.list.sum(), type=_UNKNOWN)
 
 
-def _expr_cell(expression: pl.Expr, *, type: DataType = _UNKNOWN) -> Cell:  # noqa: A002
+def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002
     from portabellas.containers._cell._expr_cell import ExprCell  # circular import  # noqa: PLC0415
 
     return ExprCell(expression, type=type)

--- a/src/portabellas/query/_list_operations/_expr_list_operations.py
+++ b/src/portabellas/query/_list_operations/_expr_list_operations.py
@@ -100,6 +100,7 @@ def _to_string_expression(value: ConvertibleToStringCell) -> pl.Expr:
         return pl.lit(value, dtype=pl.Utf8)
     return pl.lit(value)
 
+
 def _inner_type_if_list(type: DataType) -> DataType:  # noqa: A002
     if isinstance(type, DataTypes.List):
         return type.inner

--- a/src/portabellas/query/_math_operations/_expr_math_operations.py
+++ b/src/portabellas/query/_math_operations/_expr_math_operations.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from portabellas.containers import Cell
 
 _FLOAT64 = DataTypes.Float64()
-_UNKNOWN = DataTypes.Unknown()
 
 
 class ExprMathOperations(MathOperations):
@@ -110,7 +109,7 @@ class ExprMathOperations(MathOperations):
         return _expr_cell(self._expression.tanh(), type=_FLOAT64)
 
 
-def _expr_cell(expression: pl.Expr, *, type: DataType = _UNKNOWN) -> Cell:  # noqa: A002
+def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002
     from portabellas.containers._cell._expr_cell import ExprCell  # circular import  # noqa: PLC0415
 
     return ExprCell(expression, type=type)

--- a/src/portabellas/query/_string_operations/_expr_string_operations.py
+++ b/src/portabellas/query/_string_operations/_expr_string_operations.py
@@ -178,7 +178,7 @@ class ExprStringOperations(StringOperations):
         return _expr_cell(self._expression.str.to_uppercase(), type=_STRING)
 
 
-def _expr_cell(expression: pl.Expr, *, type: DataType = _UNKNOWN) -> Cell:  # noqa: A002
+def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002
     from portabellas.containers._cell._expr_cell import ExprCell  # circular import  # noqa: PLC0415
 
     return ExprCell(expression, type=type)

--- a/src/portabellas/query/_struct_operations/_expr_struct_operations.py
+++ b/src/portabellas/query/_struct_operations/_expr_struct_operations.py
@@ -66,7 +66,7 @@ class ExprStructOperations(StructOperations):
         return _expr_cell(self._expression.struct.json_encode(), type=_STRING)
 
 
-def _expr_cell(expression: pl.Expr, *, type: DataType = _UNKNOWN) -> Cell:  # noqa: A002
+def _expr_cell(expression: pl.Expr, *, type: DataType) -> Cell:  # noqa: A002
     from portabellas.containers._cell._expr_cell import ExprCell  # circular import  # noqa: PLC0415
 
     return ExprCell(expression, type=type)

--- a/tests/portabellas/_validation/test_check_type.py
+++ b/tests/portabellas/_validation/test_check_type.py
@@ -118,7 +118,7 @@ class TestCheckType:
         [
             pytest.param(DataTypes.Unknown(), id="DataType Unknown"),
             pytest.param(DataTypes.Null(), id="DataType Null"),
-            pytest.param(ExprCell(pl.col("a")), id="ExprCell with Unknown type"),
+            pytest.param(ExprCell(pl.col("a"), type=DataTypes.Unknown()), id="ExprCell with Unknown type"),
             pytest.param(ExprCell(pl.col("a"), type=DataTypes.Null()), id="ExprCell with Null type"),
             pytest.param(None, id="None literal"),
             pytest.param(object(), id="arbitrary object"),

--- a/tests/portabellas/containers/_cell/test_add.py
+++ b/tests/portabellas/containers/_cell/test_add.py
@@ -35,7 +35,11 @@ class TestShouldComputeAddition:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell + ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell + ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeAddition:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) + cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) + cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: float | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.add(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeAddition:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.add(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.add(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_and.py
+++ b/tests/portabellas/containers/_cell/test_and.py
@@ -38,7 +38,7 @@ class TestShouldComputeConjunction:
     def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: bool | None, expected: bool | None) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell & ExprCell(pl.lit(value2)),
+            lambda cell: cell & ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
             expected,
             type_if_none=DataTypes.Boolean(),
         )
@@ -54,7 +54,7 @@ class TestShouldComputeConjunction:
     ) -> None:
         assert_cell_operation_works(
             value2,
-            lambda cell: ExprCell(pl.lit(value1)) & cell,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) & cell,
             expected,
             type_if_none=DataTypes.Boolean(),
         )
@@ -65,7 +65,7 @@ class TestShouldComputeConjunction:
     def test_named_method_wrapped_in_cell(self, value1: Any, value2: bool | None, expected: bool | None) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.and_(ExprCell(pl.lit(value2))),
+            lambda cell: cell.and_(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
             expected,
             type_if_none=DataTypes.Boolean(),
         )

--- a/tests/portabellas/containers/_cell/test_div.py
+++ b/tests/portabellas/containers/_cell/test_div.py
@@ -35,7 +35,11 @@ class TestShouldComputeDivision:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell / ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell / ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeDivision:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) / cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) / cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: float | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.div(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeDivision:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.div(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.div(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_eq.py
+++ b/tests/portabellas/containers/_cell/test_eq.py
@@ -36,7 +36,11 @@ class TestShouldComputeEquality:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell == ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell == ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -52,7 +56,11 @@ class TestShouldComputeEquality:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) == cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) == cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: bool | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.eq(value2), expected)
@@ -63,7 +71,11 @@ class TestShouldComputeEquality:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.eq(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.eq(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(
@@ -93,7 +105,7 @@ class TestShouldComputeEqualityWithPropagatingNulls:
     ) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.eq(ExprCell(pl.lit(value2)), propagate_nulls=True),
+            lambda cell: cell.eq(ExprCell(pl.lit(value2), type=DataTypes.Unknown()), propagate_nulls=True),
             expected,
         )
 

--- a/tests/portabellas/containers/_cell/test_floordiv.py
+++ b/tests/portabellas/containers/_cell/test_floordiv.py
@@ -35,7 +35,11 @@ class TestShouldComputeFlooredDivision:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell // ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell // ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeFlooredDivision:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) // cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) // cell,
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_ge.py
+++ b/tests/portabellas/containers/_cell/test_ge.py
@@ -35,7 +35,11 @@ class TestShouldComputeGreaterThanOrEqual:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell >= ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell >= ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeGreaterThanOrEqual:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) >= cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) >= cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: bool | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.ge(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeGreaterThanOrEqual:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.ge(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.ge(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_gt.py
+++ b/tests/portabellas/containers/_cell/test_gt.py
@@ -35,7 +35,11 @@ class TestShouldComputeGreaterThan:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell > ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell > ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeGreaterThan:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) > cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) > cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: bool | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.gt(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeGreaterThan:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.gt(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.gt(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_le.py
+++ b/tests/portabellas/containers/_cell/test_le.py
@@ -35,7 +35,11 @@ class TestShouldComputeLessThanOrEqual:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell <= ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell <= ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeLessThanOrEqual:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) <= cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) <= cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: bool | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.le(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeLessThanOrEqual:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.le(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.le(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_lt.py
+++ b/tests/portabellas/containers/_cell/test_lt.py
@@ -35,7 +35,11 @@ class TestShouldComputeLessThan:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell < ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell < ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeLessThan:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) < cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) < cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: bool | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.lt(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeLessThan:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.lt(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.lt(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_mod.py
+++ b/tests/portabellas/containers/_cell/test_mod.py
@@ -35,7 +35,11 @@ class TestShouldComputeModulus:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell % ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell % ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeModulus:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) % cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) % cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: float | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.mod(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeModulus:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.mod(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.mod(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_mul.py
+++ b/tests/portabellas/containers/_cell/test_mul.py
@@ -35,7 +35,11 @@ class TestShouldComputeMultiplication:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell * ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell * ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeMultiplication:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) * cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) * cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: float | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.mul(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeMultiplication:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.mul(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.mul(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_neq.py
+++ b/tests/portabellas/containers/_cell/test_neq.py
@@ -36,7 +36,11 @@ class TestShouldComputeInequality:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell != ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell != ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -52,7 +56,11 @@ class TestShouldComputeInequality:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) != cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) != cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: bool | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.neq(value2), expected)
@@ -63,7 +71,11 @@ class TestShouldComputeInequality:
         value2: float | None,
         expected: bool | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.neq(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.neq(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(
@@ -93,7 +105,7 @@ class TestShouldComputeInequalityWithPropagatingNulls:
     ) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.neq(ExprCell(pl.lit(value2)), propagate_nulls=True),
+            lambda cell: cell.neq(ExprCell(pl.lit(value2), type=DataTypes.Unknown()), propagate_nulls=True),
             expected,
         )
 

--- a/tests/portabellas/containers/_cell/test_or.py
+++ b/tests/portabellas/containers/_cell/test_or.py
@@ -38,7 +38,7 @@ class TestShouldComputeDisjunction:
     def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: bool | None, expected: bool | None) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell | ExprCell(pl.lit(value2)),
+            lambda cell: cell | ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
             expected,
             type_if_none=DataTypes.Boolean(),
         )
@@ -54,7 +54,7 @@ class TestShouldComputeDisjunction:
     ) -> None:
         assert_cell_operation_works(
             value2,
-            lambda cell: ExprCell(pl.lit(value1)) | cell,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) | cell,
             expected,
             type_if_none=DataTypes.Boolean(),
         )
@@ -65,7 +65,7 @@ class TestShouldComputeDisjunction:
     def test_named_method_wrapped_in_cell(self, value1: Any, value2: bool | None, expected: bool | None) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.or_(ExprCell(pl.lit(value2))),
+            lambda cell: cell.or_(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
             expected,
             type_if_none=DataTypes.Boolean(),
         )

--- a/tests/portabellas/containers/_cell/test_pow.py
+++ b/tests/portabellas/containers/_cell/test_pow.py
@@ -40,7 +40,7 @@ class TestShouldComputePower:
     ) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell ** ExprCell(pl.lit(value2, dtype=pl.Float64())),
+            lambda cell: cell ** ExprCell(pl.lit(value2, dtype=pl.Float64()), type=DataTypes.Unknown()),
             expected,
             type_if_none=DataTypes.Float64(),
         )
@@ -64,7 +64,7 @@ class TestShouldComputePower:
     ) -> None:
         assert_cell_operation_works(
             value2,
-            lambda cell: ExprCell(pl.lit(value1, dtype=pl.Float64())) ** cell,
+            lambda cell: ExprCell(pl.lit(value1, dtype=pl.Float64()), type=DataTypes.Unknown()) ** cell,
             expected,
             type_if_none=DataTypes.Float64(),
         )
@@ -83,7 +83,7 @@ class TestShouldComputePower:
     ) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.pow(ExprCell(pl.lit(value2, dtype=pl.Float64()))),
+            lambda cell: cell.pow(ExprCell(pl.lit(value2, dtype=pl.Float64()), type=DataTypes.Unknown())),
             expected,
             type_if_none=DataTypes.Float64(),
         )

--- a/tests/portabellas/containers/_cell/test_repr.py
+++ b/tests/portabellas/containers/_cell/test_repr.py
@@ -3,6 +3,7 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.typing import DataTypes
 
 
 @pytest.mark.parametrize(
@@ -14,7 +15,7 @@ from portabellas.containers._cell import ExprCell
             id="constant",
         ),
         pytest.param(
-            ExprCell(pl.col("a")),
+            ExprCell(pl.col("a"), type=DataTypes.Unknown()),
             'ExprCell(col("a"))',
             id="column",
         ),

--- a/tests/portabellas/containers/_cell/test_str.py
+++ b/tests/portabellas/containers/_cell/test_str.py
@@ -3,6 +3,7 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.typing import DataTypes
 
 
 @pytest.mark.parametrize(
@@ -14,7 +15,7 @@ from portabellas.containers._cell import ExprCell
             id="constant",
         ),
         pytest.param(
-            ExprCell(pl.col("a")),
+            ExprCell(pl.col("a"), type=DataTypes.Unknown()),
             'col("a")',
             id="column",
         ),

--- a/tests/portabellas/containers/_cell/test_sub.py
+++ b/tests/portabellas/containers/_cell/test_sub.py
@@ -35,7 +35,11 @@ class TestShouldComputeSubtraction:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell - ExprCell(pl.lit(value2)), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell - ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+        )
 
     def test_dunder_method_inverted_order(
         self,
@@ -51,7 +55,11 @@ class TestShouldComputeSubtraction:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value2, lambda cell: ExprCell(pl.lit(value1)) - cell, expected)
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) - cell,
+            expected,
+        )
 
     def test_named_method(self, value1: float | None, value2: float | None, expected: float | None) -> None:
         assert_cell_operation_works(value1, lambda cell: cell.sub(value2), expected)
@@ -62,7 +70,11 @@ class TestShouldComputeSubtraction:
         value2: float | None,
         expected: float | None,
     ) -> None:
-        assert_cell_operation_works(value1, lambda cell: cell.sub(ExprCell(pl.lit(value2))), expected)
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.sub(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/portabellas/containers/_cell/test_xor.py
+++ b/tests/portabellas/containers/_cell/test_xor.py
@@ -38,7 +38,7 @@ class TestShouldComputeExclusiveOr:
     def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: bool | None, expected: bool | None) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell ^ ExprCell(pl.lit(value2)),
+            lambda cell: cell ^ ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
             expected,
             type_if_none=DataTypes.Boolean(),
         )
@@ -54,7 +54,7 @@ class TestShouldComputeExclusiveOr:
     ) -> None:
         assert_cell_operation_works(
             value2,
-            lambda cell: ExprCell(pl.lit(value1)) ^ cell,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) ^ cell,
             expected,
             type_if_none=DataTypes.Boolean(),
         )
@@ -65,7 +65,7 @@ class TestShouldComputeExclusiveOr:
     def test_named_method_wrapped_in_cell(self, value1: Any, value2: bool | None, expected: bool | None) -> None:
         assert_cell_operation_works(
             value1,
-            lambda cell: cell.xor(ExprCell(pl.lit(value2))),
+            lambda cell: cell.xor(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
             expected,
             type_if_none=DataTypes.Boolean(),
         )

--- a/tests/portabellas/query/_list_operations/test_first.py
+++ b/tests/portabellas/query/_list_operations/test_first.py
@@ -1,7 +1,15 @@
+from collections.abc import Callable
+
 import pytest
 
-from portabellas.typing import DataTypes
-from tests.helpers import assert_cell_operation_works
+from portabellas.containers import Cell
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+)
 
 
 @pytest.mark.parametrize(
@@ -19,3 +27,37 @@ def test_should_get_first_element(value: list | None, expected: int | None) -> N
         expected,
         type_=DataTypes.List(DataTypes.Int64()),
     )
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(
+            DataTypes.List(DataTypes.Int64()), lambda cell: cell.list.first(), DataTypes.Int64(), id="int_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.String()), lambda cell: cell.list.first(), DataTypes.String(), id="string_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Float64()), lambda cell: cell.list.first(), DataTypes.Float64(), id="float_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Boolean()), lambda cell: cell.list.first(), DataTypes.Boolean(), id="bool_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Date()), lambda cell: cell.list.first(), DataTypes.Date(), id="date_list"
+        ),
+        pytest.param(DataTypes.Unknown(), lambda cell: cell.list.first(), DataTypes.Unknown(), id="unknown"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/query/_list_operations/test_get.py
+++ b/tests/portabellas/query/_list_operations/test_get.py
@@ -1,8 +1,15 @@
+from collections.abc import Callable
+
 import pytest
 
 from portabellas.containers import Cell
-from portabellas.typing import DataTypes
-from tests.helpers import assert_cell_operation_works
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+)
 
 
 @pytest.mark.parametrize(
@@ -34,3 +41,35 @@ class TestShouldGetElementAtIndex:
             expected,
             type_=DataTypes.List(DataTypes.Int64()),
         )
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(
+            DataTypes.List(DataTypes.Int64()), lambda cell: cell.list.get(0), DataTypes.Int64(), id="int_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.String()), lambda cell: cell.list.get(0), DataTypes.String(), id="string_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Float64()), lambda cell: cell.list.get(0), DataTypes.Float64(), id="float_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Boolean()), lambda cell: cell.list.get(0), DataTypes.Boolean(), id="bool_list"
+        ),
+        pytest.param(DataTypes.List(DataTypes.Date()), lambda cell: cell.list.get(0), DataTypes.Date(), id="date_list"),
+        pytest.param(DataTypes.Unknown(), lambda cell: cell.list.get(0), DataTypes.Unknown(), id="unknown"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/query/_list_operations/test_last.py
+++ b/tests/portabellas/query/_list_operations/test_last.py
@@ -1,7 +1,15 @@
+from collections.abc import Callable
+
 import pytest
 
-from portabellas.typing import DataTypes
-from tests.helpers import assert_cell_operation_works
+from portabellas.containers import Cell
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+)
 
 
 @pytest.mark.parametrize(
@@ -19,3 +27,35 @@ def test_should_get_last_element(value: list | None, expected: int | None) -> No
         expected,
         type_=DataTypes.List(DataTypes.Int64()),
     )
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(
+            DataTypes.List(DataTypes.Int64()), lambda cell: cell.list.last(), DataTypes.Int64(), id="int_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.String()), lambda cell: cell.list.last(), DataTypes.String(), id="string_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Float64()), lambda cell: cell.list.last(), DataTypes.Float64(), id="float_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Boolean()), lambda cell: cell.list.last(), DataTypes.Boolean(), id="bool_list"
+        ),
+        pytest.param(DataTypes.List(DataTypes.Date()), lambda cell: cell.list.last(), DataTypes.Date(), id="date_list"),
+        pytest.param(DataTypes.Unknown(), lambda cell: cell.list.last(), DataTypes.Unknown(), id="unknown"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/query/_list_operations/test_max.py
+++ b/tests/portabellas/query/_list_operations/test_max.py
@@ -1,7 +1,15 @@
+from collections.abc import Callable
+
 import pytest
 
-from portabellas.typing import DataTypes
-from tests.helpers import assert_cell_operation_works
+from portabellas.containers import Cell
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+)
 
 
 @pytest.mark.parametrize(
@@ -21,3 +29,33 @@ def test_should_get_max_value(value: list | None, expected: int | None) -> None:
         expected,
         type_=DataTypes.List(DataTypes.Int64()),
     )
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(DataTypes.List(DataTypes.Int64()), lambda cell: cell.list.max(), DataTypes.Int64(), id="int_list"),
+        pytest.param(
+            DataTypes.List(DataTypes.String()), lambda cell: cell.list.max(), DataTypes.String(), id="string_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Float64()), lambda cell: cell.list.max(), DataTypes.Float64(), id="float_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Boolean()), lambda cell: cell.list.max(), DataTypes.Boolean(), id="bool_list"
+        ),
+        pytest.param(DataTypes.List(DataTypes.Date()), lambda cell: cell.list.max(), DataTypes.Date(), id="date_list"),
+        pytest.param(DataTypes.Unknown(), lambda cell: cell.list.max(), DataTypes.Unknown(), id="unknown"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/query/_list_operations/test_min.py
+++ b/tests/portabellas/query/_list_operations/test_min.py
@@ -1,7 +1,15 @@
+from collections.abc import Callable
+
 import pytest
 
-from portabellas.typing import DataTypes
-from tests.helpers import assert_cell_operation_works
+from portabellas.containers import Cell
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+)
 
 
 @pytest.mark.parametrize(
@@ -21,3 +29,33 @@ def test_should_get_min_value(value: list | None, expected: int | None) -> None:
         expected,
         type_=DataTypes.List(DataTypes.Int64()),
     )
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(DataTypes.List(DataTypes.Int64()), lambda cell: cell.list.min(), DataTypes.Int64(), id="int_list"),
+        pytest.param(
+            DataTypes.List(DataTypes.String()), lambda cell: cell.list.min(), DataTypes.String(), id="string_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Float64()), lambda cell: cell.list.min(), DataTypes.Float64(), id="float_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Boolean()), lambda cell: cell.list.min(), DataTypes.Boolean(), id="bool_list"
+        ),
+        pytest.param(DataTypes.List(DataTypes.Date()), lambda cell: cell.list.min(), DataTypes.Date(), id="date_list"),
+        pytest.param(DataTypes.Unknown(), lambda cell: cell.list.min(), DataTypes.Unknown(), id="unknown"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/query/_list_operations/test_sum.py
+++ b/tests/portabellas/query/_list_operations/test_sum.py
@@ -1,7 +1,15 @@
+from collections.abc import Callable
+
 import pytest
 
-from portabellas.typing import DataTypes
-from tests.helpers import assert_cell_operation_works
+from portabellas.containers import Cell
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+)
 
 
 @pytest.mark.parametrize(
@@ -20,3 +28,38 @@ def test_should_sum_list_elements(value: list | None, expected: int | None) -> N
         expected,
         type_=DataTypes.List(DataTypes.Int64()),
     )
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(DataTypes.List(DataTypes.Int8()), lambda cell: cell.list.sum(), DataTypes.Int64(), id="int8_list"),
+        pytest.param(
+            DataTypes.List(DataTypes.UInt8()), lambda cell: cell.list.sum(), DataTypes.Int64(), id="uint8_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Int64()), lambda cell: cell.list.sum(), DataTypes.Int64(), id="int64_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Boolean()), lambda cell: cell.list.sum(), DataTypes.UInt32(), id="bool_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Float32()), lambda cell: cell.list.sum(), DataTypes.Float32(), id="float32_list"
+        ),
+        pytest.param(
+            DataTypes.List(DataTypes.Float64()), lambda cell: cell.list.sum(), DataTypes.Float64(), id="float64_list"
+        ),
+        pytest.param(DataTypes.Unknown(), lambda cell: cell.list.sum(), DataTypes.Unknown(), id="unknown"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)


### PR DESCRIPTION
Closes #132

### Summary of Changes

- Propagate the list's inner type as the result type for list element-extraction methods, falling back to `Unknown` when the cell type is not a known `List`.
- Use `infer_operation_type` for `list.sum` to correctly handle Polars type promotion rather than returning the inner type directly.
