### PR TITLE
feat(query): add Cell.dur.full_nanoseconds

### DIFF
--- a/src/portabellas/query/_duration_operations/_duration_operations.py
+++ b/src/portabellas/query/_duration_operations/_duration_operations.py
@@ -224,9 +224,6 @@ class DurationOperations(ABC):
         """
         Get the number of full microseconds in the duration. The result is rounded toward zero.
 
-        Since durations only have microsecond resolution at the moment, the rounding has no effect. This may change in
-        the future.
-
         Returns
         -------
         cell:
@@ -245,6 +242,33 @@ class DurationOperations(ABC):
         +======+
         | 1001 |
         |  999 |
+        | null |
+        +------+
+        """
+
+    @abstractmethod
+    def full_nanoseconds(self) -> Cell:
+        """
+        Get the number of full nanoseconds in the duration. The result is rounded toward zero.
+
+        Returns
+        -------
+        cell:
+            The number of full nanoseconds.
+
+        Examples
+        --------
+        >>> from datetime import timedelta
+        >>> from portabellas import Column
+        >>> column = Column("a", [timedelta(microseconds=1), timedelta(microseconds=0), None])
+        >>> column.map(lambda cell: cell.dur.full_nanoseconds())
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        | 1000 |
+        |    0 |
         | null |
         +------+
         """

--- a/src/portabellas/query/_duration_operations/_expr_duration_operations.py
+++ b/src/portabellas/query/_duration_operations/_expr_duration_operations.py
@@ -44,6 +44,9 @@ class ExprDurationOperations(DurationOperations):
     def full_microseconds(self) -> Cell:
         return _expr_cell(self._expression.dt.total_microseconds(), type=_INT64)
 
+    def full_nanoseconds(self) -> Cell:
+        return _expr_cell(self._expression.dt.total_nanoseconds(), type=_INT64)
+
     def to_string(
         self,
         *,

--- a/tests/portabellas/query/_duration_operations/test_full_nanoseconds.py
+++ b/tests/portabellas/query/_duration_operations/test_full_nanoseconds.py
@@ -1,0 +1,52 @@
+from collections.abc import Callable
+from datetime import timedelta
+
+import pytest
+
+from portabellas.containers import Cell
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(timedelta(microseconds=1), 1000, id="positive, exact"),
+        pytest.param(timedelta(microseconds=-1), -1000, id="negative, exact"),
+        pytest.param(timedelta(milliseconds=1, microseconds=-500), 500000, id="mixed"),
+        pytest.param(None, None, id="None"),
+    ],
+)
+def test_should_return_full_nanoseconds(value: timedelta | None, expected: int | None) -> None:
+    assert_cell_operation_works(
+        value,
+        lambda cell: cell.dur.full_nanoseconds(),
+        expected,
+        type_if_none=DataTypes.Duration("us"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(
+            DataTypes.Duration("us"), lambda cell: cell.dur.full_nanoseconds(), DataTypes.Int64(), id="duration"
+        ),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)


### PR DESCRIPTION
Closes #176

### Summary of Changes

- Add `full_nanoseconds` to the duration namespace, consistent with the existing `full_*` methods.
