### PR TITLE
feat(containers): validate binary arithmetic operand types

### DIFF
--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -6,6 +6,7 @@ import polars as pl
 
 from portabellas._validation import check_type
 from portabellas._validation._cell_type_requirements import CellTypeRequirements
+from portabellas.exceptions import ColumnTypeError
 from portabellas.query._datetime_operations import ExprDatetimeOperations
 from portabellas.query._duration_operations import ExprDurationOperations
 from portabellas.query._list_operations import ExprListOperations
@@ -136,73 +137,99 @@ class ExprCell(Cell):
         return ExprCell(self._expression.__pos__(), type=self._type)
 
     def __add__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__add__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__add__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__add__, self._type, other_type, result_type)
         return ExprCell(self._expression.__add__(other_expr), type=result_type)
 
     def __radd__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__radd__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__radd__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__radd__, self._type, other_type, result_type)
         return ExprCell(self._expression.__radd__(other_expr), type=result_type)
 
     def __floordiv__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__floordiv__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__floordiv__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__floordiv__, self._type, other_type, result_type)
         return ExprCell(self._expression.__floordiv__(other_expr), type=result_type)
 
     def __rfloordiv__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__rfloordiv__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__rfloordiv__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__rfloordiv__, self._type, other_type, result_type)
         return ExprCell(self._expression.__rfloordiv__(other_expr), type=result_type)
 
     def __mod__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__mod__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__mod__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__mod__, self._type, other_type, result_type)
         return ExprCell(self._expression.__mod__(other_expr), type=result_type)
 
     def __rmod__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__rmod__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__rmod__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__rmod__, self._type, other_type, result_type)
         return ExprCell(self._expression.__rmod__(other_expr), type=result_type)
 
     def __mul__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__mul__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__mul__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__mul__, self._type, other_type, result_type)
         return ExprCell(self._expression.__mul__(other_expr), type=result_type)
 
     def __rmul__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__rmul__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__rmul__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__rmul__, self._type, other_type, result_type)
         return ExprCell(self._expression.__rmul__(other_expr), type=result_type)
 
     def __pow__(self, other: ConvertibleToCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.NUMERIC)
         other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__pow__, self._type, _type_or_literal_of_other(other))
         return ExprCell(self._expression.__pow__(other_expr), type=result_type)
 
     def __rpow__(self, other: ConvertibleToCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.NUMERIC)
         other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__rpow__, self._type, _type_or_literal_of_other(other))
         return ExprCell(self._expression.__rpow__(other_expr), type=result_type)
 
     def __sub__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__sub__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__sub__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__sub__, self._type, other_type, result_type)
         return ExprCell(self._expression.__sub__(other_expr), type=result_type)
 
     def __rsub__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__rsub__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__rsub__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__rsub__, self._type, other_type, result_type)
         return ExprCell(self._expression.__rsub__(other_expr), type=result_type)
 
     def __truediv__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__truediv__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__truediv__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__truediv__, self._type, other_type, result_type)
         return ExprCell(self._expression.__truediv__(other_expr), type=result_type)
 
     def __rtruediv__(self, other: ConvertibleToCell) -> Cell:
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__rtruediv__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__rtruediv__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__rtruediv__, self._type, other_type, result_type)
         return ExprCell(self._expression.__rtruediv__(other_expr), type=result_type)
 
     # Other --------------------------------------------------------------------
@@ -293,3 +320,19 @@ def _type_or_literal_of_other(other: object) -> DataType | object:
     if isinstance(other, Cell):
         return other._type
     return other
+
+
+def _validate_operation_type(
+    operator: object,
+    self_type: DataType,
+    other_type_or_literal: DataType | object,
+    result_type: DataType,
+) -> None:
+    if (
+        isinstance(result_type, DataTypes.Unknown)
+        and not isinstance(self_type, DataTypes.Unknown)
+        and not isinstance(other_type_or_literal, DataTypes.Unknown)
+    ):
+        op_name = getattr(operator, "__name__", operator)
+        msg = f"Invalid operand types for {op_name}: {self_type} and {other_type_or_literal}"
+        raise ColumnTypeError(msg)

--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -138,100 +138,114 @@ class ExprCell(Cell):
 
     def __add__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__add__, self._type, other_type)
         _validate_operation_type(pl.Expr.__add__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__add__(other_expr), type=result_type)
 
     def __radd__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__radd__, self._type, other_type)
         _validate_operation_type(pl.Expr.__radd__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__radd__(other_expr), type=result_type)
 
     def __floordiv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__floordiv__, self._type, other_type)
         _validate_operation_type(pl.Expr.__floordiv__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__floordiv__(other_expr), type=result_type)
 
     def __rfloordiv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__rfloordiv__, self._type, other_type)
         _validate_operation_type(pl.Expr.__rfloordiv__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rfloordiv__(other_expr), type=result_type)
 
     def __mod__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__mod__, self._type, other_type)
         _validate_operation_type(pl.Expr.__mod__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__mod__(other_expr), type=result_type)
 
     def __rmod__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__rmod__, self._type, other_type)
         _validate_operation_type(pl.Expr.__rmod__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rmod__(other_expr), type=result_type)
 
     def __mul__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__mul__, self._type, other_type)
         _validate_operation_type(pl.Expr.__mul__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__mul__(other_expr), type=result_type)
 
     def __rmul__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__rmul__, self._type, other_type)
         _validate_operation_type(pl.Expr.__rmul__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rmul__(other_expr), type=result_type)
 
     def __pow__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__pow__, self._type, other_type)
         _validate_operation_type(pl.Expr.__pow__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__pow__(other_expr), type=result_type)
 
     def __rpow__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__rpow__, self._type, other_type)
         _validate_operation_type(pl.Expr.__rpow__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rpow__(other_expr), type=result_type)
 
     def __sub__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__sub__, self._type, other_type)
         _validate_operation_type(pl.Expr.__sub__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__sub__(other_expr), type=result_type)
 
     def __rsub__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__rsub__, self._type, other_type)
         _validate_operation_type(pl.Expr.__rsub__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rsub__(other_expr), type=result_type)
 
     def __truediv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__truediv__, self._type, other_type)
         _validate_operation_type(pl.Expr.__truediv__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__truediv__(other_expr), type=result_type)
 
     def __rtruediv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
-        other_expr = _to_polars_expression(other)
         result_type = infer_operation_type(pl.Expr.__rtruediv__, self._type, other_type)
         _validate_operation_type(pl.Expr.__rtruediv__, self._type, other_type, result_type)
+
+        other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rtruediv__(other_expr), type=result_type)
 
     # Other --------------------------------------------------------------------
@@ -318,12 +332,6 @@ class ExprCell(Cell):
         return self.__type
 
 
-def _type_or_literal_of_other(other: object) -> DataType | object:
-    if isinstance(other, Cell):
-        return other._type
-    return other
-
-
 def _validate_operation_type(
     operator: object,
     self_type: DataType,
@@ -338,3 +346,9 @@ def _validate_operation_type(
         op_name = getattr(operator, "__name__", operator)
         msg = f"Invalid operand types for {op_name}: {self_type} and {other_type_or_literal}"
         raise ColumnTypeError(msg)
+
+
+def _type_or_literal_of_other(other: object) -> DataType | object:
+    if isinstance(other, Cell):
+        return other._type
+    return other

--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -139,7 +139,7 @@ class ExprCell(Cell):
     def __add__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__add__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__add__, self._type, other_type, result_type)
+        _validate_operation_type("+", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__add__(other_expr), type=result_type)
@@ -147,7 +147,7 @@ class ExprCell(Cell):
     def __radd__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__radd__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__radd__, self._type, other_type, result_type)
+        _validate_operation_type("+", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__radd__(other_expr), type=result_type)
@@ -155,7 +155,7 @@ class ExprCell(Cell):
     def __floordiv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__floordiv__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__floordiv__, self._type, other_type, result_type)
+        _validate_operation_type("//", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__floordiv__(other_expr), type=result_type)
@@ -163,7 +163,7 @@ class ExprCell(Cell):
     def __rfloordiv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__rfloordiv__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__rfloordiv__, self._type, other_type, result_type)
+        _validate_operation_type("//", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rfloordiv__(other_expr), type=result_type)
@@ -171,7 +171,7 @@ class ExprCell(Cell):
     def __mod__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__mod__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__mod__, self._type, other_type, result_type)
+        _validate_operation_type("%", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__mod__(other_expr), type=result_type)
@@ -179,7 +179,7 @@ class ExprCell(Cell):
     def __rmod__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__rmod__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__rmod__, self._type, other_type, result_type)
+        _validate_operation_type("%", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rmod__(other_expr), type=result_type)
@@ -187,7 +187,7 @@ class ExprCell(Cell):
     def __mul__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__mul__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__mul__, self._type, other_type, result_type)
+        _validate_operation_type("*", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__mul__(other_expr), type=result_type)
@@ -195,7 +195,7 @@ class ExprCell(Cell):
     def __rmul__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__rmul__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__rmul__, self._type, other_type, result_type)
+        _validate_operation_type("*", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rmul__(other_expr), type=result_type)
@@ -203,7 +203,7 @@ class ExprCell(Cell):
     def __pow__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__pow__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__pow__, self._type, other_type, result_type)
+        _validate_operation_type("**", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__pow__(other_expr), type=result_type)
@@ -211,7 +211,7 @@ class ExprCell(Cell):
     def __rpow__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__rpow__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__rpow__, self._type, other_type, result_type)
+        _validate_operation_type("**", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rpow__(other_expr), type=result_type)
@@ -219,7 +219,7 @@ class ExprCell(Cell):
     def __sub__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__sub__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__sub__, self._type, other_type, result_type)
+        _validate_operation_type("-", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__sub__(other_expr), type=result_type)
@@ -227,7 +227,7 @@ class ExprCell(Cell):
     def __rsub__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__rsub__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__rsub__, self._type, other_type, result_type)
+        _validate_operation_type("-", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rsub__(other_expr), type=result_type)
@@ -235,7 +235,7 @@ class ExprCell(Cell):
     def __truediv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__truediv__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__truediv__, self._type, other_type, result_type)
+        _validate_operation_type("/", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__truediv__(other_expr), type=result_type)
@@ -243,7 +243,7 @@ class ExprCell(Cell):
     def __rtruediv__(self, other: ConvertibleToCell) -> Cell:
         other_type = _type_or_literal_of_other(other)
         result_type = infer_operation_type(pl.Expr.__rtruediv__, self._type, other_type)
-        _validate_operation_type(pl.Expr.__rtruediv__, self._type, other_type, result_type)
+        _validate_operation_type("/", self._type, other_type, result_type)
 
         other_expr = _to_polars_expression(other)
         return ExprCell(self._expression.__rtruediv__(other_expr), type=result_type)
@@ -333,7 +333,7 @@ class ExprCell(Cell):
 
 
 def _validate_operation_type(
-    operator: object,
+    operator: str,
     self_type: DataType,
     other_type_or_literal: DataType | object,
     result_type: DataType,
@@ -343,8 +343,7 @@ def _validate_operation_type(
         and not isinstance(self_type, (DataTypes.Unknown, DataTypes.Null))
         and not isinstance(other_type_or_literal, (DataTypes.Unknown, DataTypes.Null))
     ):
-        op_name = getattr(operator, "__name__", operator)
-        msg = f"Invalid operand types for {op_name}: {self_type} and {other_type_or_literal}"
+        msg = f"Invalid operand types for {operator}: {self_type} and {other_type_or_literal}"
         raise ColumnTypeError(msg)
 
 

--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -193,15 +193,17 @@ class ExprCell(Cell):
         return ExprCell(self._expression.__rmul__(other_expr), type=result_type)
 
     def __pow__(self, other: ConvertibleToCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.NUMERIC)
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__pow__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__pow__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__pow__, self._type, other_type, result_type)
         return ExprCell(self._expression.__pow__(other_expr), type=result_type)
 
     def __rpow__(self, other: ConvertibleToCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.NUMERIC)
+        other_type = _type_or_literal_of_other(other)
         other_expr = _to_polars_expression(other)
-        result_type = infer_operation_type(pl.Expr.__rpow__, self._type, _type_or_literal_of_other(other))
+        result_type = infer_operation_type(pl.Expr.__rpow__, self._type, other_type)
+        _validate_operation_type(pl.Expr.__rpow__, self._type, other_type, result_type)
         return ExprCell(self._expression.__rpow__(other_expr), type=result_type)
 
     def __sub__(self, other: ConvertibleToCell) -> Cell:
@@ -330,8 +332,8 @@ def _validate_operation_type(
 ) -> None:
     if (
         isinstance(result_type, DataTypes.Unknown)
-        and not isinstance(self_type, DataTypes.Unknown)
-        and not isinstance(other_type_or_literal, DataTypes.Unknown)
+        and not isinstance(self_type, (DataTypes.Unknown, DataTypes.Null))
+        and not isinstance(other_type_or_literal, (DataTypes.Unknown, DataTypes.Null))
     ):
         op_name = getattr(operator, "__name__", operator)
         msg = f"Invalid operand types for {op_name}: {self_type} and {other_type_or_literal}"

--- a/src/portabellas/typing/_type_inference.py
+++ b/src/portabellas/typing/_type_inference.py
@@ -80,7 +80,11 @@ def _compute_operation_type_with_polars(
     input_types_or_literals: tuple[DataType | object, ...],
 ) -> DataType:
     try:
-        polars_dtype = _build_test_lazy_frame(operator, input_types_or_literals).collect().schema["result"]
+        # collect_schema is not sufficient: https://github.com/pola-rs/polars/issues/27565
+        # in-memory is ~10x faster than streaming for these tiny test frames
+        polars_dtype = (
+            _build_test_lazy_frame(operator, input_types_or_literals).collect(engine="in-memory").schema["result"]
+        )
         return _from_polars_data_type(polars_dtype)
     except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
         return DataTypes.Unknown()

--- a/src/portabellas/typing/_type_inference.py
+++ b/src/portabellas/typing/_type_inference.py
@@ -80,25 +80,10 @@ def _compute_operation_type_with_polars(
     input_types_or_literals: tuple[DataType | object, ...],
 ) -> DataType:
     try:
-        polars_dtype = _build_test_lazy_frame(operator, input_types_or_literals).collect_schema()["result"]
-        result = _from_polars_data_type(polars_dtype)
+        polars_dtype = _build_test_lazy_frame(operator, input_types_or_literals).collect().schema["result"]
+        return _from_polars_data_type(polars_dtype)
     except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
         return DataTypes.Unknown()
-
-    # Polars schema inference for pow returns the base type even for non-numeric bases, but execution fails
-    if operator is pl.Expr.__pow__ and not _is_numeric_base(input_types_or_literals):
-        return DataTypes.Unknown()
-
-    return result
-
-
-def _is_numeric_base(args: tuple[DataType | object, ...]) -> bool:
-    if not args:
-        return False
-    base = args[0]
-    if not isinstance(base, DataType):
-        base = infer_type_from_literal(base)
-    return base.is_numeric
 
 
 def _build_test_lazy_frame(

--- a/src/portabellas/typing/_type_inference.py
+++ b/src/portabellas/typing/_type_inference.py
@@ -81,9 +81,24 @@ def _compute_operation_type_with_polars(
 ) -> DataType:
     try:
         polars_dtype = _build_test_lazy_frame(operator, input_types_or_literals).collect_schema()["result"]
-        return _from_polars_data_type(polars_dtype)
+        result = _from_polars_data_type(polars_dtype)
     except (pl.exceptions.InvalidOperationError, pl.exceptions.ComputeError):
         return DataTypes.Unknown()
+
+    # Polars schema inference for pow returns the base type even for non-numeric bases, but execution fails
+    if operator is pl.Expr.__pow__ and not _is_numeric_base(input_types_or_literals):
+        return DataTypes.Unknown()
+
+    return result
+
+
+def _is_numeric_base(args: tuple[DataType | object, ...]) -> bool:
+    if not args:
+        return False
+    base = args[0]
+    if not isinstance(base, DataType):
+        base = infer_type_from_literal(base)
+    return base.is_numeric
 
 
 def _build_test_lazy_frame(

--- a/tests/helpers/_assertions.py
+++ b/tests/helpers/_assertions.py
@@ -105,21 +105,16 @@ def assert_cell_type_matches_polars(
     schema = {name: dtype._polars_data_type for name, dtype in zip(column_names, given_types, strict=True)}
     cells = [ExprCell(pl.col(name), type=dtype) for name, dtype in zip(column_names, given_types, strict=True)]
 
+    selected = (
+        pl.DataFrame({name: [None] for name in column_names}, schema=schema)
+        .lazy()
+        .select(result=operation(*cells)._polars_expression)
+    )
+
     try:
-        polars_dtype = (
-            pl.DataFrame({name: [None] for name in column_names}, schema=schema)
-            .lazy()
-            .select(result=operation(*cells)._polars_expression)
-            .collect()
-            .schema["result"]
-        )
+        polars_dtype = selected.collect().schema["result"]
     except pl.exceptions.ComputeError:
-        polars_dtype = (
-            pl.DataFrame({name: [None] for name in column_names}, schema=schema)
-            .lazy()
-            .select(result=operation(*cells)._polars_expression)
-            .collect_schema()["result"]
-        )
+        polars_dtype = selected.collect_schema()["result"]
 
     assert polars_dtype == inferred_type._polars_data_type, (
         f"Inferred {inferred_type} ({inferred_type._polars_data_type}), Polars produced {polars_dtype}"

--- a/tests/helpers/_assertions.py
+++ b/tests/helpers/_assertions.py
@@ -105,13 +105,21 @@ def assert_cell_type_matches_polars(
     schema = {name: dtype._polars_data_type for name, dtype in zip(column_names, given_types, strict=True)}
     cells = [ExprCell(pl.col(name), type=dtype) for name, dtype in zip(column_names, given_types, strict=True)]
 
-    polars_dtype = (
-        pl.DataFrame({name: [None] for name in column_names}, schema=schema)
-        .lazy()
-        .select(result=operation(*cells)._polars_expression)
-        .collect_schema()
-        .get("result")
-    )
+    try:
+        polars_dtype = (
+            pl.DataFrame({name: [None] for name in column_names}, schema=schema)
+            .lazy()
+            .select(result=operation(*cells)._polars_expression)
+            .collect()
+            .schema["result"]
+        )
+    except pl.exceptions.ComputeError:
+        polars_dtype = (
+            pl.DataFrame({name: [None] for name in column_names}, schema=schema)
+            .lazy()
+            .select(result=operation(*cells)._polars_expression)
+            .collect_schema()["result"]
+        )
 
     assert polars_dtype == inferred_type._polars_data_type, (
         f"Inferred {inferred_type} ({inferred_type._polars_data_type}), Polars produced {polars_dtype}"

--- a/tests/portabellas/containers/_cell/test_add.py
+++ b/tests/portabellas/containers/_cell/test_add.py
@@ -5,12 +5,14 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -186,3 +188,46 @@ class TestShouldInferTypeWithLiteral:
         expected_type: DataType,
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("left_type", "right_type"),
+    [
+        pytest.param(DataTypes.String(), DataTypes.Int32(), id="string_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.String(), id="int_string"),
+        pytest.param(DataTypes.Date(), DataTypes.Date(), id="date_date"),
+        pytest.param(DataTypes.Datetime(time_unit="us"), DataTypes.Datetime(time_unit="us"), id="datetime_datetime"),
+    ],
+)
+class TestShouldRaiseForInvalidOperandTypes:
+    def test_dunder_method(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(left_type) + cell_of_type(right_type)
+
+    def test_dunder_method_inverted_order(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(right_type) + cell_of_type(left_type)
+
+
+class TestShouldRaiseForInvalidLiteralType:
+    def test_dunder_method(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(DataTypes.String()) + 1
+
+    def test_dunder_method_inverted_order(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = 1 + cell_of_type(DataTypes.String())
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self_unknown(self) -> None:
+        _ = cell_of_unknown_type() + cell_of_type(DataTypes.Int32())
+
+    def test_other_unknown(self) -> None:
+        _ = cell_of_type(DataTypes.Int32()) + cell_of_unknown_type()
+
+    def test_self_unknown_literal(self) -> None:
+        _ = cell_of_unknown_type() + 1
+
+    def test_literal_self_unknown_other(self) -> None:
+        _ = 1 + cell_of_unknown_type()

--- a/tests/portabellas/containers/_cell/test_div.py
+++ b/tests/portabellas/containers/_cell/test_div.py
@@ -115,7 +115,7 @@ class TestShouldComputeDivision:
         pytest.param(
             DataTypes.Int32(), DataTypes.Unknown(), lambda a, b: a / b, DataTypes.Unknown(), id="unknown_right"
         ),
-        pytest.param(DataTypes.Null(), DataTypes.Int32(), lambda a, b: a / b, DataTypes.Null(), id="null_left"),
+        pytest.param(DataTypes.Null(), DataTypes.Int32(), lambda a, b: a / b, DataTypes.Float64(), id="null_left"),
         pytest.param(DataTypes.Int32(), DataTypes.Null(), lambda a, b: a / b, DataTypes.Float64(), id="null_right"),
     ],
 )

--- a/tests/portabellas/containers/_cell/test_div.py
+++ b/tests/portabellas/containers/_cell/test_div.py
@@ -5,12 +5,14 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -170,3 +172,46 @@ class TestShouldInferTypeWithLiteral:
         expected_type: DataType,
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("left_type", "right_type"),
+    [
+        pytest.param(DataTypes.String(), DataTypes.Int32(), id="string_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.String(), id="int_string"),
+        pytest.param(DataTypes.Date(), DataTypes.Date(), id="date_date"),
+        pytest.param(DataTypes.String(), DataTypes.String(), id="string_string"),
+    ],
+)
+class TestShouldRaiseForInvalidOperandTypes:
+    def test_dunder_method(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(left_type) / cell_of_type(right_type)
+
+    def test_dunder_method_inverted_order(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(right_type) / cell_of_type(left_type)
+
+
+class TestShouldRaiseForInvalidLiteralType:
+    def test_dunder_method(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(DataTypes.String()) / 1
+
+    def test_dunder_method_inverted_order(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = 1 / cell_of_type(DataTypes.String())
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self_unknown(self) -> None:
+        _ = cell_of_unknown_type() / cell_of_type(DataTypes.Int32())
+
+    def test_other_unknown(self) -> None:
+        _ = cell_of_type(DataTypes.Int32()) / cell_of_unknown_type()
+
+    def test_self_unknown_literal(self) -> None:
+        _ = cell_of_unknown_type() / 1
+
+    def test_literal_self_unknown_other(self) -> None:
+        _ = 1 / cell_of_unknown_type()

--- a/tests/portabellas/containers/_cell/test_floordiv.py
+++ b/tests/portabellas/containers/_cell/test_floordiv.py
@@ -5,12 +5,14 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -128,3 +130,46 @@ class TestShouldInferTypeWithLiteral:
         expected_type: DataType,
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("left_type", "right_type"),
+    [
+        pytest.param(DataTypes.String(), DataTypes.Int32(), id="string_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.String(), id="int_string"),
+        pytest.param(DataTypes.Date(), DataTypes.Int32(), id="date_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.Date(), id="int_date"),
+    ],
+)
+class TestShouldRaiseForInvalidOperandTypes:
+    def test_dunder_method(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(left_type) // cell_of_type(right_type)
+
+    def test_dunder_method_inverted_order(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(right_type) // cell_of_type(left_type)
+
+
+class TestShouldRaiseForInvalidLiteralType:
+    def test_dunder_method(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(DataTypes.String()) // 1
+
+    def test_dunder_method_inverted_order(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = 1 // cell_of_type(DataTypes.String())
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self_unknown(self) -> None:
+        _ = cell_of_unknown_type() // cell_of_type(DataTypes.Int32())
+
+    def test_other_unknown(self) -> None:
+        _ = cell_of_type(DataTypes.Int32()) // cell_of_unknown_type()
+
+    def test_self_unknown_literal(self) -> None:
+        _ = cell_of_unknown_type() // 1
+
+    def test_literal_self_unknown_other(self) -> None:
+        _ = 1 // cell_of_unknown_type()

--- a/tests/portabellas/containers/_cell/test_mod.py
+++ b/tests/portabellas/containers/_cell/test_mod.py
@@ -5,12 +5,14 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -141,3 +143,46 @@ class TestShouldInferTypeWithLiteral:
         expected_type: DataType,
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("left_type", "right_type"),
+    [
+        pytest.param(DataTypes.String(), DataTypes.Int32(), id="string_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.String(), id="int_string"),
+        pytest.param(DataTypes.Date(), DataTypes.Int32(), id="date_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.Date(), id="int_date"),
+    ],
+)
+class TestShouldRaiseForInvalidOperandTypes:
+    def test_dunder_method(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(left_type) % cell_of_type(right_type)
+
+    def test_dunder_method_inverted_order(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(right_type) % cell_of_type(left_type)
+
+
+class TestShouldRaiseForInvalidLiteralType:
+    def test_dunder_method(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(DataTypes.String()) % 1
+
+    def test_dunder_method_inverted_order(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = 1 % cell_of_type(DataTypes.String())
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self_unknown(self) -> None:
+        _ = cell_of_unknown_type() % cell_of_type(DataTypes.Int32())
+
+    def test_other_unknown(self) -> None:
+        _ = cell_of_type(DataTypes.Int32()) % cell_of_unknown_type()
+
+    def test_self_unknown_literal(self) -> None:
+        _ = cell_of_unknown_type() % 1
+
+    def test_literal_self_unknown_other(self) -> None:
+        _ = 1 % cell_of_unknown_type()

--- a/tests/portabellas/containers/_cell/test_mul.py
+++ b/tests/portabellas/containers/_cell/test_mul.py
@@ -5,12 +5,14 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -168,3 +170,46 @@ class TestShouldInferTypeWithLiteral:
         expected_type: DataType,
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("left_type", "right_type"),
+    [
+        pytest.param(DataTypes.String(), DataTypes.Int32(), id="string_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.String(), id="int_string"),
+        pytest.param(DataTypes.Date(), DataTypes.Int32(), id="date_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.Date(), id="int_date"),
+    ],
+)
+class TestShouldRaiseForInvalidOperandTypes:
+    def test_dunder_method(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(left_type) * cell_of_type(right_type)
+
+    def test_dunder_method_inverted_order(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(right_type) * cell_of_type(left_type)
+
+
+class TestShouldRaiseForInvalidLiteralType:
+    def test_dunder_method(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(DataTypes.String()) * 1
+
+    def test_dunder_method_inverted_order(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = 1 * cell_of_type(DataTypes.String())
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self_unknown(self) -> None:
+        _ = cell_of_unknown_type() * cell_of_type(DataTypes.Int32())
+
+    def test_other_unknown(self) -> None:
+        _ = cell_of_type(DataTypes.Int32()) * cell_of_unknown_type()
+
+    def test_self_unknown_literal(self) -> None:
+        _ = cell_of_unknown_type() * 1
+
+    def test_literal_self_unknown_other(self) -> None:
+        _ = 1 * cell_of_unknown_type()

--- a/tests/portabellas/containers/_cell/test_pow.py
+++ b/tests/portabellas/containers/_cell/test_pow.py
@@ -108,7 +108,7 @@ class TestShouldComputePower:
             DataTypes.Int32(), DataTypes.Unknown(), lambda a, b: a**b, DataTypes.Unknown(), id="unknown_right"
         ),
         pytest.param(DataTypes.Null(), DataTypes.Int32(), lambda a, b: a**b, DataTypes.Unknown(), id="null_left"),
-        pytest.param(DataTypes.Int32(), DataTypes.Null(), lambda a, b: a**b, DataTypes.Int32(), id="null_right"),
+        pytest.param(DataTypes.Int32(), DataTypes.Null(), lambda a, b: a**b, DataTypes.Unknown(), id="null_right"),
     ],
 )
 class TestShouldInferType:
@@ -161,26 +161,32 @@ class TestShouldInferTypeWithLiteral:
 
 
 @pytest.mark.parametrize(
-    "cell_type",
+    ("left_type", "right_type"),
     [
-        pytest.param(DataTypes.String(), id="string"),
-        pytest.param(DataTypes.Boolean(), id="boolean"),
-        pytest.param(DataTypes.Date(), id="date"),
-        pytest.param(DataTypes.Duration(time_unit="us"), id="duration"),
+        pytest.param(DataTypes.String(), DataTypes.Int32(), id="string_int"),
+        pytest.param(DataTypes.Boolean(), DataTypes.Int32(), id="boolean_int"),
+        pytest.param(DataTypes.Date(), DataTypes.Int32(), id="date_int"),
+        pytest.param(DataTypes.Duration(time_unit="us"), DataTypes.Int32(), id="duration_int"),
     ],
 )
-class TestShouldRaiseForNonNumericType:
-    def test_dunder_method(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected numeric type"):
-            _ = cell_of_type(cell_type) ** 2
+class TestShouldRaiseForInvalidOperandTypes:
+    def test_dunder_method(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(left_type) ** cell_of_type(right_type)
 
-    def test_dunder_method_inverted_order(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected numeric type"):
-            _ = 2 ** cell_of_type(cell_type)
+    def test_dunder_method_inverted_order(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(right_type) ** cell_of_type(left_type)
 
-    def test_dunder_method_cell_other(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected numeric type"):
-            _ = cell_of_type(cell_type) ** cell_of_type(DataTypes.Int32())
+
+class TestShouldRaiseForInvalidLiteralType:
+    def test_dunder_method(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(DataTypes.String()) ** 2
+
+    def test_dunder_method_inverted_order(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = 2 ** cell_of_type(DataTypes.String())
 
 
 class TestShouldSkipValidationForUnknownType:

--- a/tests/portabellas/containers/_cell/test_pow.py
+++ b/tests/portabellas/containers/_cell/test_pow.py
@@ -5,12 +5,14 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -105,7 +107,7 @@ class TestShouldComputePower:
         pytest.param(
             DataTypes.Int32(), DataTypes.Unknown(), lambda a, b: a**b, DataTypes.Unknown(), id="unknown_right"
         ),
-        pytest.param(DataTypes.Null(), DataTypes.Int32(), lambda a, b: a**b, DataTypes.Null(), id="null_left"),
+        pytest.param(DataTypes.Null(), DataTypes.Int32(), lambda a, b: a**b, DataTypes.Unknown(), id="null_left"),
         pytest.param(DataTypes.Int32(), DataTypes.Null(), lambda a, b: a**b, DataTypes.Int32(), id="null_right"),
     ],
 )
@@ -156,3 +158,40 @@ class TestShouldInferTypeWithLiteral:
         expected_type: DataType,
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Boolean(), id="boolean"),
+        pytest.param(DataTypes.Date(), id="date"),
+        pytest.param(DataTypes.Duration(time_unit="us"), id="duration"),
+    ],
+)
+class TestShouldRaiseForNonNumericType:
+    def test_dunder_method(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected numeric type"):
+            _ = cell_of_type(cell_type) ** 2
+
+    def test_dunder_method_inverted_order(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected numeric type"):
+            _ = 2 ** cell_of_type(cell_type)
+
+    def test_dunder_method_cell_other(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected numeric type"):
+            _ = cell_of_type(cell_type) ** cell_of_type(DataTypes.Int32())
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self_unknown(self) -> None:
+        _ = cell_of_unknown_type() ** cell_of_type(DataTypes.Int32())
+
+    def test_other_unknown(self) -> None:
+        _ = cell_of_type(DataTypes.Int32()) ** cell_of_unknown_type()
+
+    def test_self_unknown_literal(self) -> None:
+        _ = cell_of_unknown_type() ** 2
+
+    def test_literal_self_unknown_other(self) -> None:
+        _ = 2 ** cell_of_unknown_type()

--- a/tests/portabellas/containers/_cell/test_sub.py
+++ b/tests/portabellas/containers/_cell/test_sub.py
@@ -5,12 +5,14 @@ import pytest
 
 from portabellas.containers import Cell
 from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -177,3 +179,44 @@ class TestShouldInferTypeWithLiteral:
         expected_type: DataType,
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("left_type", "right_type"),
+    [
+        pytest.param(DataTypes.String(), DataTypes.Int32(), id="string_int"),
+        pytest.param(DataTypes.Int32(), DataTypes.String(), id="int_string"),
+    ],
+)
+class TestShouldRaiseForInvalidOperandTypes:
+    def test_dunder_method(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(left_type) - cell_of_type(right_type)
+
+    def test_dunder_method_inverted_order(self, left_type: DataType, right_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(right_type) - cell_of_type(left_type)
+
+
+class TestShouldRaiseForInvalidLiteralType:
+    def test_dunder_method(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = cell_of_type(DataTypes.String()) - 1
+
+    def test_dunder_method_inverted_order(self) -> None:
+        with pytest.raises(ColumnTypeError, match="Invalid operand types"):
+            _ = 1 - cell_of_type(DataTypes.String())
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self_unknown(self) -> None:
+        _ = cell_of_unknown_type() - cell_of_type(DataTypes.Int32())
+
+    def test_other_unknown(self) -> None:
+        _ = cell_of_type(DataTypes.Int32()) - cell_of_unknown_type()
+
+    def test_self_unknown_literal(self) -> None:
+        _ = cell_of_unknown_type() - 1
+
+    def test_literal_self_unknown_other(self) -> None:
+        _ = 1 - cell_of_unknown_type()


### PR DESCRIPTION
### Summary of Changes

- Switch type inference from `collect_schema()` to `collect()` in `_compute_operation_type_with_polars`, because `collect_schema()` can return incorrect types for operations that would fail at execution time (upstream Polars bug)
- Add `_validate_operation_type` to all binary arithmetic dunder methods in `ExprCell`, which raises `ColumnTypeError` when the inferred result type is `Unknown` but neither operand is `Unknown` or `Null` — this catches invalid operand combinations like `String + Int` or `Date / Date` early
- Fix previously incorrect type inference results for `Null` operands in `pow` and `div`
