### PR TITLE
docs: add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,13 +1,16 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: '3.13'
-  commands:
-    - pip install uv
-    - uv sync --only-group docs
-    - uv run mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml
+    python: "3.13"
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.13'
+  commands:
+    - pip install uv
+    - uv sync --only-group docs
+    - uv run mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml
+
+mkdocs:
+  configuration: mkdocs.yml


### PR DESCRIPTION
Closes #68

### Summary of Changes

- Add `.readthedocs.yaml` to configure ReadTheDocs as the documentation hosting provider, using native uv support for dependency installation and Python 3.13 on Ubuntu 24.04.
