### PR TITLE
feat(query): add struct.get(name) field name validation

### DIFF
--- a/src/portabellas/_validation/__init__.py
+++ b/src/portabellas/_validation/__init__.py
@@ -9,6 +9,7 @@ from ._check_datetime_format import check_and_convert_datetime_format
 from ._check_indices import check_indices
 from ._check_row_counts_are_equal import check_row_counts_are_equal
 from ._check_schema import check_schema
+from ._check_struct_field_exists import check_struct_field_exists
 from ._check_time_zone import check_time_zone
 from ._check_type import CellTypeRequirement, InstanceOf, check_type
 from ._normalize_and_check_file_path import normalize_and_check_file_path
@@ -27,6 +28,7 @@ __all__ = [
     "check_indices",
     "check_row_counts_are_equal",
     "check_schema",
+    "check_struct_field_exists",
     "check_time_zone",
     "check_type",
     "normalize_and_check_file_path",

--- a/src/portabellas/_validation/_check_columns_are_numeric.py
+++ b/src/portabellas/_validation/_check_columns_are_numeric.py
@@ -1,5 +1,3 @@
-"""The module name must differ from the function name, so it can be re-exported properly."""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/portabellas/_validation/_check_columns_are_permutation.py
+++ b/src/portabellas/_validation/_check_columns_are_permutation.py
@@ -1,5 +1,3 @@
-"""The module name must differ from the function name, so it can be re-exported properly."""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/portabellas/_validation/_check_columns_dont_exist.py
+++ b/src/portabellas/_validation/_check_columns_dont_exist.py
@@ -1,5 +1,3 @@
-"""The module name must differ from the function name, so it can be re-exported properly."""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/portabellas/_validation/_check_columns_exist.py
+++ b/src/portabellas/_validation/_check_columns_exist.py
@@ -1,5 +1,3 @@
-"""The module name must differ from the function name, so it can be re-exported properly."""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/portabellas/_validation/_check_schema.py
+++ b/src/portabellas/_validation/_check_schema.py
@@ -1,5 +1,3 @@
-"""The module name must differ from the function name, so it can be re-exported properly."""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/portabellas/_validation/_check_struct_field_exists.py
+++ b/src/portabellas/_validation/_check_struct_field_exists.py
@@ -1,0 +1,32 @@
+"""The module name must differ from the function name, so it can be re-exported properly."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from portabellas.exceptions import StructFieldNotFoundError
+
+if TYPE_CHECKING:
+    from portabellas.typing import DataTypes
+
+
+def check_struct_field_exists(name: str, struct_type: DataTypes.Struct) -> None:
+    """
+    Check whether the specified field exists in a struct type, and raise an error if it does not.
+
+    Parameters
+    ----------
+    name:
+        The field name to check.
+    struct_type:
+        The struct type whose fields are checked.
+
+    Raises
+    ------
+    StructFieldNotFoundError
+        If the field name does not exist in the struct.
+    """
+    if name not in struct_type.fields:
+        available = list(struct_type.fields.keys())
+        msg = f'Struct has no field "{name}". Available fields: {available}'
+        raise StructFieldNotFoundError(msg) from None

--- a/src/portabellas/_validation/_check_struct_field_exists.py
+++ b/src/portabellas/_validation/_check_struct_field_exists.py
@@ -1,5 +1,3 @@
-"""The module name must differ from the function name, so it can be re-exported properly."""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/portabellas/_validation/_check_struct_field_exists.py
+++ b/src/portabellas/_validation/_check_struct_field_exists.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from portabellas._utils import get_similar_strings
 from portabellas.exceptions import StructFieldNotFoundError
 
 if TYPE_CHECKING:
@@ -27,6 +28,19 @@ def check_struct_field_exists(name: str, struct_type: DataTypes.Struct) -> None:
         If the field name does not exist in the struct.
     """
     if name not in struct_type.fields:
-        available = list(struct_type.fields.keys())
-        msg = f'Struct has no field "{name}". Available fields: {available}'
+        sorted_fields = _sort_fields_by_similarity(name, struct_type)
+        msg = _build_error_message(name, sorted_fields)
         raise StructFieldNotFoundError(msg) from None
+
+
+def _sort_fields_by_similarity(name: str, struct_type: DataTypes.Struct) -> list[str]:
+    similar = get_similar_strings(name, struct_type.fields.keys())
+    remaining = [field for field in struct_type.fields if field not in similar]
+    return similar + remaining
+
+
+def _build_error_message(name: str, sorted_fields: list[str]) -> str:
+    result = f'Struct has no field "{name}". Available fields:\n'
+    for field in sorted_fields:
+        result += f'    - "{field}"\n'
+    return result.rstrip("\n")

--- a/src/portabellas/exceptions/__init__.py
+++ b/src/portabellas/exceptions/__init__.py
@@ -42,6 +42,10 @@ class SchemaError(PortabellasError, ValueError):
     """Raised when a schema does not match the expected schema."""
 
 
+class StructFieldNotFoundError(PortabellasError, KeyError):
+    """Raised when a struct field is not found."""
+
+
 __all__ = [
     "ColumnNotFoundError",
     "ColumnNullError",
@@ -54,4 +58,5 @@ __all__ = [
     "OutOfBoundsError",
     "PortabellasError",
     "SchemaError",
+    "StructFieldNotFoundError",
 ]

--- a/src/portabellas/query/_struct_operations/_expr_struct_operations.py
+++ b/src/portabellas/query/_struct_operations/_expr_struct_operations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from portabellas._validation import check_struct_field_exists
 from portabellas.typing import DataType, DataTypes
 
 from ._struct_operations import StructOperations
@@ -32,7 +33,11 @@ class ExprStructOperations(StructOperations):
     # ------------------------------------------------------------------------------------------------------------------
 
     def get(self, name: str) -> Cell:
-        result_type = self._type.fields[name] if isinstance(self._type, DataTypes.Struct) else _UNKNOWN
+        if isinstance(self._type, DataTypes.Struct):
+            check_struct_field_exists(name, self._type)
+            result_type = self._type.fields[name]
+        else:
+            result_type = _UNKNOWN
         return _expr_cell(self._expression.struct.field(name), type=result_type)
 
     def rename(self, old_name: str, new_name: str) -> Cell:

--- a/tests/portabellas/query/_struct_operations/test_get.py
+++ b/tests/portabellas/query/_struct_operations/test_get.py
@@ -87,18 +87,26 @@ class TestShouldInferType:
 
 
 @pytest.mark.parametrize(
-    ("given_type", "field_name"),
+    ("given_type", "field_name", "expected_message"),
     [
         pytest.param(
             DataTypes.Struct(fields={"name": DataTypes.String(), "age": DataTypes.Int64()}),
             "missing",
-            id="known_type",
+            'Struct has no field "missing". Available fields:\n    - "name"\n    - "age"',
+            id="no_similar_fields",
+        ),
+        pytest.param(
+            DataTypes.Struct(fields={"name": DataTypes.String(), "age": DataTypes.Int64()}),
+            "nme",
+            'Struct has no field "nme". Available fields:\n    - "name"\n    - "age"',
+            id="similar_field_sorted_first",
         ),
     ],
 )
-def test_should_raise_if_field_does_not_exist(given_type: DataType, field_name: str) -> None:
-    with pytest.raises(StructFieldNotFoundError, match=f'Struct has no field "{field_name}"'):
+def test_should_raise_if_field_does_not_exist(given_type: DataType, field_name: str, expected_message: str) -> None:
+    with pytest.raises(StructFieldNotFoundError) as exc_info:
         cell_of_type(given_type).struct.get(field_name)
+    assert str(exc_info.value.args[0]) == expected_message
 
 
 def test_should_not_raise_if_type_is_unknown() -> None:

--- a/tests/portabellas/query/_struct_operations/test_get.py
+++ b/tests/portabellas/query/_struct_operations/test_get.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import StructFieldNotFoundError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
@@ -83,3 +84,22 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("given_type", "field_name"),
+    [
+        pytest.param(
+            DataTypes.Struct(fields={"name": DataTypes.String(), "age": DataTypes.Int64()}),
+            "missing",
+            id="known_type",
+        ),
+    ],
+)
+def test_should_raise_if_field_does_not_exist(given_type: DataType, field_name: str) -> None:
+    with pytest.raises(StructFieldNotFoundError, match=f'Struct has no field "{field_name}"'):
+        cell_of_type(given_type).struct.get(field_name)
+
+
+def test_should_not_raise_if_type_is_unknown() -> None:
+    cell_of_type(DataTypes.Unknown()).struct.get("missing")

--- a/tests/portabellas/query/_struct_operations/test_getitem.py
+++ b/tests/portabellas/query/_struct_operations/test_getitem.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import StructFieldNotFoundError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
@@ -83,3 +84,22 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    ("given_type", "field_name"),
+    [
+        pytest.param(
+            DataTypes.Struct(fields={"name": DataTypes.String(), "age": DataTypes.Int64()}),
+            "missing",
+            id="known_type",
+        ),
+    ],
+)
+def test_should_raise_if_field_does_not_exist(given_type: DataType, field_name: str) -> None:
+    with pytest.raises(StructFieldNotFoundError, match=f'Struct has no field "{field_name}"'):
+        cell_of_type(given_type).struct[field_name]
+
+
+def test_should_not_raise_if_type_is_unknown() -> None:
+    cell_of_type(DataTypes.Unknown()).struct["missing"]

--- a/tests/portabellas/query/_struct_operations/test_getitem.py
+++ b/tests/portabellas/query/_struct_operations/test_getitem.py
@@ -87,18 +87,26 @@ class TestShouldInferType:
 
 
 @pytest.mark.parametrize(
-    ("given_type", "field_name"),
+    ("given_type", "field_name", "expected_message"),
     [
         pytest.param(
             DataTypes.Struct(fields={"name": DataTypes.String(), "age": DataTypes.Int64()}),
             "missing",
-            id="known_type",
+            'Struct has no field "missing". Available fields:\n    - "name"\n    - "age"',
+            id="no_similar_fields",
+        ),
+        pytest.param(
+            DataTypes.Struct(fields={"name": DataTypes.String(), "age": DataTypes.Int64()}),
+            "nme",
+            'Struct has no field "nme". Available fields:\n    - "name"\n    - "age"',
+            id="similar_field_sorted_first",
         ),
     ],
 )
-def test_should_raise_if_field_does_not_exist(given_type: DataType, field_name: str) -> None:
-    with pytest.raises(StructFieldNotFoundError, match=f'Struct has no field "{field_name}"'):
+def test_should_raise_if_field_does_not_exist(given_type: DataType, field_name: str, expected_message: str) -> None:
+    with pytest.raises(StructFieldNotFoundError) as exc_info:
         cell_of_type(given_type).struct[field_name]
+    assert str(exc_info.value.args[0]) == expected_message
 
 
 def test_should_not_raise_if_type_is_unknown() -> None:


### PR DESCRIPTION
Closes #138

### Summary of Changes

- Validate field names in `struct.get` / `struct.__getitem__`, raising `StructFieldNotFoundError` early instead of failing at Polars evaluation time
- Error message lists all available fields sorted by similarity (closest first)
