### PR TITLE
feat: add convenience imports at package top level

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ uv run ruff check --fix && uv run ruff format && uv run mypy src tests && uv run
 
 ## Architecture
 
-- **Src layout**: `src/portabellas/` is the package. Public API: `Table`, `Column`, `Row`, `Cell` from `portabellas.containers`; `DataType`, `Schema` from `portabellas.typing`.
+- **Src layout**: `src/portabellas/` is the package. Public API: `Table`, `Column`, `Row`, `Cell` from `portabellas.containers`; `DataType`, `DataTypes`, `Schema` from `portabellas.typing`; `PortabellasError` from `portabellas.exceptions`. All are also available at the top level (`from portabellas import ...`) for convenience. Documentation is generated from the subpackage locations only.
 - **Core submodules**: `containers/`, `query/` (cell operation namespaces), `typing/`, `io/`, `plotting/`, `exceptions/`, `_validation/`, `_config/`, `_utils/`.
 - **Polars LazyFrame internally**: Both `Table` and `Column` store `_lazy_frame` (LazyFrame) as the primary representation. `_data_frame`/`_series` are lazily cached properties — accessed via `._data_frame` / `._series`, which collect on first access and re-anchor the LazyFrame. `Table.schema` is similarly cached in `__schema_cache`. Use `safely_collect_lazy_frame` / `safely_collect_lazy_frame_schema` from `_utils` (not `.collect()` directly).
 - **IO**: `TableReader` (static methods: `csv_file`, `json_file`, `parquet_file`, `jsonl_file`) and `TableWriter` (instance methods on `self._table`). Factory/export methods (`from_columns`, `from_dict`, `to_columns`, `to_dict`) are on `Table` directly, not via `Table.read.*`/`table.write.*`.

--- a/docs/reference/generate_reference_pages.py
+++ b/docs/reference/generate_reference_pages.py
@@ -37,6 +37,10 @@ for path in sorted(Path(root).rglob("__init__.py")):
     # Remove the final "__init__" part
     parts = parts[:-1]
 
+    # Skip top-level package init — docs are generated from subpackage locations only
+    if parts == (package,):
+        continue
+
     # Skip private modules
     if any(part.startswith("_") for part in parts):
         continue

--- a/src/portabellas/__init__.py
+++ b/src/portabellas/__init__.py
@@ -1,3 +1,5 @@
-from .containers import Column, Table
+from .containers import Cell, Column, Row, Table
+from .exceptions import PortabellasError
+from .typing import DataType, DataTypes, Schema
 
-__all__ = ["Column", "Table"]
+__all__ = ["Cell", "Column", "DataType", "DataTypes", "PortabellasError", "Row", "Schema", "Table"]


### PR DESCRIPTION
### Summary of Changes

- Re-export `Cell`, `Row`, `DataType`, `DataTypes`, `Schema`, and `PortabellasError` at the package top level (`from portabellas import ...`) for convenience. These classes remain available from their canonical subpackages (`portabellas.containers`, `portabellas.typing`, `portabellas.exceptions`) as well.
- Skip the top-level `__init__.py` in the reference docs generator so that documentation pages are only produced for the subpackage locations, avoiding duplicate entries.
