### PR TITLE
feat(query): add dt.* method-level type validation

### DIFF
--- a/src/portabellas/_validation/_cell_type_requirements.py
+++ b/src/portabellas/_validation/_cell_type_requirements.py
@@ -6,6 +6,9 @@ from portabellas.typing import DataTypes
 
 class CellTypeRequirements:
     BOOLEAN = InstanceOf(DataTypes.Boolean)
+    DATE_OR_DATETIME = InstanceOf(DataTypes.Date, DataTypes.Datetime)
+    DATETIME = InstanceOf(DataTypes.Datetime)
+    DATETIME_OR_TIME = InstanceOf(DataTypes.Datetime, DataTypes.Time)
     DT = InstanceOf(DataTypes.Date, DataTypes.Datetime, DataTypes.Time)
     DURATION = InstanceOf(DataTypes.Duration)
     LIST = CellTypeRequirement("list", lambda t: t.is_list)

--- a/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
+++ b/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from portabellas._validation import check_and_convert_datetime_format
+from portabellas._validation import check_and_convert_datetime_format, check_type
+from portabellas._validation._cell_type_requirements import CellTypeRequirements
 from portabellas.containers._cell._cell import _to_polars_expression
 from portabellas.typing import DataType, DataTypes
 
@@ -31,54 +32,71 @@ class ExprDatetimeOperations(DatetimeOperations):
         self._type: DataType = type
 
     def century(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.century(), type=_INT32)
 
     def date(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATETIME)
         return _expr_cell(self._expression.dt.date(), type=_DATE)
 
     def day(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.day(), type=_INT8)
 
     def day_of_week(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.weekday(), type=_INT8)
 
     def day_of_year(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.ordinal_day(), type=_INT16)
 
     def hour(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATETIME_OR_TIME)
         return _expr_cell(self._expression.dt.hour(), type=_INT8)
 
     def microsecond(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATETIME_OR_TIME)
         return _expr_cell(self._expression.dt.microsecond(), type=_INT32)
 
     def millennium(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.millennium(), type=_INT32)
 
     def millisecond(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATETIME_OR_TIME)
         return _expr_cell(self._expression.dt.millisecond(), type=_INT32)
 
     def minute(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATETIME_OR_TIME)
         return _expr_cell(self._expression.dt.minute(), type=_INT8)
 
     def month(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.month(), type=_INT8)
 
     def quarter(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.quarter(), type=_INT8)
 
     def second(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATETIME_OR_TIME)
         return _expr_cell(self._expression.dt.second(), type=_INT8)
 
     def time(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATETIME)
         return _expr_cell(self._expression.dt.time(), type=_TIME)
 
     def week(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.week(), type=_INT8)
 
     def year(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.year(), type=_INT32)
 
     def is_in_leap_year(self) -> Cell:
+        check_type(self._type, required=CellTypeRequirements.DATE_OR_DATETIME)
         return _expr_cell(self._expression.dt.is_leap_year(), type=_BOOLEAN)
 
     def replace(

--- a/tests/portabellas/query/_datetime_operations/test_century.py
+++ b/tests/portabellas/query/_datetime_operations/test_century.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -49,3 +51,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.century()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.century()

--- a/tests/portabellas/query/_datetime_operations/test_date.py
+++ b/tests/portabellas/query/_datetime_operations/test_date.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -42,3 +44,20 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Date(), id="date"),
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForNonDatetimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Datetime type"):
+            _ = cell_of_type(cell_type).dt.date()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.date()

--- a/tests/portabellas/query/_datetime_operations/test_day.py
+++ b/tests/portabellas/query/_datetime_operations/test_day.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.day()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.day()

--- a/tests/portabellas/query/_datetime_operations/test_day_of_week.py
+++ b/tests/portabellas/query/_datetime_operations/test_day_of_week.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.day_of_week()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.day_of_week()

--- a/tests/portabellas/query/_datetime_operations/test_day_of_year.py
+++ b/tests/portabellas/query/_datetime_operations/test_day_of_year.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -49,3 +51,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.day_of_year()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.day_of_year()

--- a/tests/portabellas/query/_datetime_operations/test_hour.py
+++ b/tests/portabellas/query/_datetime_operations/test_hour.py
@@ -4,12 +4,14 @@ from datetime import datetime, time
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Date(), id="date"),
+    ],
+)
+class TestShouldRaiseForDateType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Datetime or Time type"):
+            _ = cell_of_type(cell_type).dt.hour()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.hour()

--- a/tests/portabellas/query/_datetime_operations/test_is_in_leap_year.py
+++ b/tests/portabellas/query/_datetime_operations/test_is_in_leap_year.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.is_in_leap_year()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.is_in_leap_year()

--- a/tests/portabellas/query/_datetime_operations/test_microsecond.py
+++ b/tests/portabellas/query/_datetime_operations/test_microsecond.py
@@ -4,12 +4,14 @@ from datetime import datetime, time
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Date(), id="date"),
+    ],
+)
+class TestShouldRaiseForDateType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Datetime or Time type"):
+            _ = cell_of_type(cell_type).dt.microsecond()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.microsecond()

--- a/tests/portabellas/query/_datetime_operations/test_millennium.py
+++ b/tests/portabellas/query/_datetime_operations/test_millennium.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -49,3 +51,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.millennium()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.millennium()

--- a/tests/portabellas/query/_datetime_operations/test_millisecond.py
+++ b/tests/portabellas/query/_datetime_operations/test_millisecond.py
@@ -4,12 +4,14 @@ from datetime import datetime, time
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Date(), id="date"),
+    ],
+)
+class TestShouldRaiseForDateType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Datetime or Time type"):
+            _ = cell_of_type(cell_type).dt.millisecond()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.millisecond()

--- a/tests/portabellas/query/_datetime_operations/test_minute.py
+++ b/tests/portabellas/query/_datetime_operations/test_minute.py
@@ -4,12 +4,14 @@ from datetime import datetime, time
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Date(), id="date"),
+    ],
+)
+class TestShouldRaiseForDateType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Datetime or Time type"):
+            _ = cell_of_type(cell_type).dt.minute()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.minute()

--- a/tests/portabellas/query/_datetime_operations/test_month.py
+++ b/tests/portabellas/query/_datetime_operations/test_month.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.month()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.month()

--- a/tests/portabellas/query/_datetime_operations/test_quarter.py
+++ b/tests/portabellas/query/_datetime_operations/test_quarter.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -49,3 +51,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.quarter()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.quarter()

--- a/tests/portabellas/query/_datetime_operations/test_second.py
+++ b/tests/portabellas/query/_datetime_operations/test_second.py
@@ -4,12 +4,14 @@ from datetime import datetime, time
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Date(), id="date"),
+    ],
+)
+class TestShouldRaiseForDateType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Datetime or Time type"):
+            _ = cell_of_type(cell_type).dt.second()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.second()

--- a/tests/portabellas/query/_datetime_operations/test_time.py
+++ b/tests/portabellas/query/_datetime_operations/test_time.py
@@ -4,12 +4,14 @@ from datetime import datetime, time
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -42,3 +44,20 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Date(), id="date"),
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForNonDatetimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Datetime type"):
+            _ = cell_of_type(cell_type).dt.time()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.time()

--- a/tests/portabellas/query/_datetime_operations/test_week.py
+++ b/tests/portabellas/query/_datetime_operations/test_week.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -49,3 +51,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.week()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.week()

--- a/tests/portabellas/query/_datetime_operations/test_year.py
+++ b/tests/portabellas/query/_datetime_operations/test_year.py
@@ -4,12 +4,14 @@ from datetime import date, datetime
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
     assert_cell_operation_works,
     assert_cell_type_matches_polars,
     cell_of_type,
+    cell_of_unknown_type,
 )
 
 
@@ -47,3 +49,19 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Time(), id="time"),
+    ],
+)
+class TestShouldRaiseForTimeType:
+    def test_should_raise(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected Date or Datetime type"):
+            _ = cell_of_type(cell_type).dt.year()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = cell_of_unknown_type().dt.year()


### PR DESCRIPTION
Closes #136

### Summary of Changes

- Add finer-grained `CellTypeRequirements` (`DATE_OR_DATETIME`, `DATETIME_OR_TIME`, `DATETIME`) so that individual `dt.*` methods can reject semantically invalid types before reaching Polars evaluation. This catches likely bugs (e.g., calling `cell.dt.year()` on a `Time` cell) with a clear `ColumnTypeError` instead of an unhelpful Polars runtime error.
