### PR TITLE
feat(query): add list.sum and list.join method-level type validation

### DIFF
--- a/src/portabellas/_validation/_cell_type_requirements.py
+++ b/src/portabellas/_validation/_cell_type_requirements.py
@@ -10,5 +10,8 @@ class CellTypeRequirements:
     DURATION = InstanceOf(DataTypes.Duration)
     LIST = CellTypeRequirement("list", lambda t: t.is_list)
     NUMERIC = CellTypeRequirement("numeric", lambda t: t.is_numeric)
+    NUMERIC_OR_BOOLEAN = CellTypeRequirement(
+        "numeric or boolean", lambda t: t.is_numeric or isinstance(t, DataTypes.Boolean)
+    )
     STRING = InstanceOf(DataTypes.String)
     STRUCT = CellTypeRequirement("struct", lambda t: t.is_struct)

--- a/src/portabellas/query/_list_operations/_expr_list_operations.py
+++ b/src/portabellas/query/_list_operations/_expr_list_operations.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
+from portabellas._validation import check_type
+from portabellas._validation._cell_type_requirements import CellTypeRequirements
 from portabellas.containers._cell._cell import Cell
 from portabellas.typing import DataType, DataTypes
 from portabellas.typing._type_inference import infer_operation_type
@@ -47,6 +49,7 @@ class ExprListOperations(ListOperations):
         return _expr_cell(self._expression.list.get(index_expr, null_on_oob=True), type=_inner_type_if_list(self._type))
 
     def join(self, separator: ConvertibleToStringCell) -> Cell:
+        check_type(_inner_type_if_list(self._type), required=CellTypeRequirements.STRING)
         separator_expr = _to_string_expression(separator)
         return _expr_cell(self._expression.list.join(separator_expr), type=_STRING)
 
@@ -69,6 +72,7 @@ class ExprListOperations(ListOperations):
         return _expr_cell(self._expression.list.sort(descending=descending), type=self._type)
 
     def sum(self) -> Cell:
+        check_type(_inner_type_if_list(self._type), required=CellTypeRequirements.NUMERIC_OR_BOOLEAN)
         result_type = infer_operation_type(lambda a: a.list.sum(), self._type)
         return _expr_cell(self._expression.list.sum(), type=result_type)
 

--- a/tests/portabellas/query/_list_operations/test_join.py
+++ b/tests/portabellas/query/_list_operations/test_join.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
@@ -59,3 +60,21 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "given_type",
+    [
+        pytest.param(DataTypes.List(DataTypes.Int64()), id="int64 inner"),
+        pytest.param(DataTypes.List(DataTypes.Float64()), id="float64 inner"),
+    ],
+)
+def test_should_raise_type_error_for_non_string_inner(given_type: DataType) -> None:
+    cell = cell_of_type(given_type)
+    with pytest.raises(ColumnTypeError):
+        cell.list.join("-")
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    cell = cell_of_type(DataTypes.Unknown())
+    cell.list.join("-")

--- a/tests/portabellas/query/_list_operations/test_sum.py
+++ b/tests/portabellas/query/_list_operations/test_sum.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import pytest
 
 from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
@@ -63,3 +64,21 @@ class TestShouldInferType:
         self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
     ) -> None:
         assert_cell_type_matches_polars(given_type, operation, expected_type)
+
+
+@pytest.mark.parametrize(
+    "given_type",
+    [
+        pytest.param(DataTypes.List(DataTypes.String()), id="string inner"),
+        pytest.param(DataTypes.List(DataTypes.Date()), id="date inner"),
+    ],
+)
+def test_should_raise_type_error_for_non_numeric_inner(given_type: DataType) -> None:
+    cell = cell_of_type(given_type)
+    with pytest.raises(ColumnTypeError):
+        cell.list.sum()
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    cell = cell_of_type(DataTypes.Unknown())
+    cell.list.sum()


### PR DESCRIPTION
Closes #137

### Summary of Changes

- Add `check_type` validation to `list.sum()` and `list.join()` so that invalid inner types (e.g., string inner for `sum`, numeric inner for `join`) raise `ColumnTypeError` eagerly instead of surfacing as confusing Polars errors at evaluation time.
