### PR TITLE
feat(query): add dt.to_string format validation based on cell type

### DIFF
--- a/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
+++ b/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
@@ -115,11 +115,13 @@ class ExprDatetimeOperations(DatetimeOperations):
         return _expr_cell(self._expression.dt.to_string(format=polars_format), type=_STRING)
 
     def _format_validation_type(self) -> Literal["datetime", "date", "time"]:
-        if isinstance(self._type, DataTypes.Date):
-            return "date"
-        if isinstance(self._type, DataTypes.Time):
-            return "time"
-        return "datetime"
+        match self._type:
+            case DataTypes.Date():
+                return "date"
+            case DataTypes.Time():
+                return "time"
+            case _:
+                return "datetime"
 
     def unix_timestamp(self, *, unit: Literal["s", "ms", "us"] = "s") -> Cell:
         return _expr_cell(self._expression.dt.epoch(time_unit=unit), type=_INT64)

--- a/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
+++ b/src/portabellas/query/_datetime_operations/_expr_datetime_operations.py
@@ -109,9 +109,17 @@ class ExprDatetimeOperations(DatetimeOperations):
         if format == "iso":
             polars_format = "iso:strict"
         else:
-            polars_format = check_and_convert_datetime_format(format, type_="datetime", used_for_parsing=False)
+            type_ = self._format_validation_type()
+            polars_format = check_and_convert_datetime_format(format, type_=type_, used_for_parsing=False)
 
         return _expr_cell(self._expression.dt.to_string(format=polars_format), type=_STRING)
+
+    def _format_validation_type(self) -> Literal["datetime", "date", "time"]:
+        if isinstance(self._type, DataTypes.Date):
+            return "date"
+        if isinstance(self._type, DataTypes.Time):
+            return "time"
+        return "datetime"
 
     def unix_timestamp(self, *, unit: Literal["s", "ms", "us"] = "s") -> Cell:
         return _expr_cell(self._expression.dt.epoch(time_unit=unit), type=_INT64)

--- a/tests/portabellas/query/_datetime_operations/test_to_string.py
+++ b/tests/portabellas/query/_datetime_operations/test_to_string.py
@@ -5,7 +5,6 @@ import pytest
 
 from portabellas import Column
 from portabellas.containers import Cell
-from portabellas.exceptions import LazyComputationError
 from portabellas.typing import DataType, DataTypes
 from tests.helpers import (
     assert_cell_has_type,
@@ -178,26 +177,28 @@ def test_should_raise_for_invalid_specifier() -> None:
 @pytest.mark.parametrize(
     ("value", "format_"),
     [
-        pytest.param(DATE, "{h}", id="invalid for date"),
-        pytest.param(
-            TIME,
-            "{Y}",
-            marks=pytest.mark.skip("polars panics in this case (https://github.com/pola-rs/polars/issues/19853)."),
-            id="invalid for time",
-        ),
+        pytest.param(DATE, "{h}", id="time specifier for date"),
+        pytest.param(DATE, "{m}", id="minute specifier for date"),
+        pytest.param(DATE, "{s}", id="second specifier for date"),
+        pytest.param(DATE, "{z}", id="timezone specifier for date"),
+        pytest.param(TIME, "{Y}", id="year specifier for time"),
+        pytest.param(TIME, "{M}", id="month specifier for time"),
+        pytest.param(TIME, "{D}", id="day specifier for time"),
+        pytest.param(TIME, "{z}", id="timezone specifier for time"),
     ],
 )
 def test_should_raise_for_specifier_that_is_invalid_for_type(value: date | time, format_: str) -> None:
     column = Column("a", [value])
-    lazy_result = column.map(lambda cell: cell.dt.to_string(format=format_))
-    with pytest.raises(LazyComputationError):
-        lazy_result[0]
+    with pytest.raises(ValueError, match="Invalid specifier"):
+        column.map(lambda cell: cell.dt.to_string(format=format_))
 
 
 @pytest.mark.parametrize(
     ("given_type", "operation", "expected_type"),
     [
         pytest.param(DataTypes.Datetime(), lambda cell: cell.dt.to_string(), DataTypes.String(), id="datetime"),
+        pytest.param(DataTypes.Date(), lambda cell: cell.dt.to_string(), DataTypes.String(), id="date"),
+        pytest.param(DataTypes.Time(), lambda cell: cell.dt.to_string(), DataTypes.String(), id="time"),
     ],
 )
 class TestShouldInferType:


### PR DESCRIPTION
Closes #139

### Summary of Changes

- Validate format specifiers in `dt.to_string` against the cell's actual type (Date, Time, or Datetime) rather than always assuming Datetime. This catches misuse early with a clear `ValueError` instead of surfacing as a `LazyComputationError` or Polars panic at evaluation time.
