### PR TITLE
feat(containers): propagate ExprCell type to Column and Table

### DIFF
--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 import polars as pl
 from polars.exceptions import InvalidOperationError
 
+_UNKNOWN = _DataTypes.Unknown()
+
 
 class Column[T_co](Sequence[T_co]):
     """
@@ -79,13 +81,13 @@ class Column[T_co](Sequence[T_co]):
         return result
 
     @staticmethod
-    def _from_polars_lazy_frame(name: str, data: pl.LazyFrame, *, type: DataType | None = None) -> Column:  # noqa: A002
+    def _from_polars_lazy_frame(name: str, data: pl.LazyFrame, *, type: DataType = _UNKNOWN) -> Column:  # noqa: A002
         result = object.__new__(Column)
         result._name = name
         result.__series_cache = None
         result._lazy_frame = data.select(name)
 
-        if type is not None and not isinstance(type, _DataTypes.Unknown):
+        if not isinstance(type, _DataTypes.Unknown):
             result.__type_cache = type
 
             if "PYTEST_CURRENT_TEST" in os.environ:

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -1178,7 +1178,7 @@ class Column[T_co](Sequence[T_co]):
     @staticmethod
     def _cross_check_type(lazy_frame: pl.LazyFrame, type: DataType) -> None:  # noqa: A002
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            return
+            return  # pragma: no cover
 
         schema = safely_collect_lazy_frame_schema(lazy_frame)
         polars_type = _from_polars_data_type(schema.dtypes()[0])

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -12,8 +12,7 @@ from portabellas._validation import (
     check_row_counts_are_equal,
 )
 from portabellas.containers._cell._expr_cell import ExprCell
-from portabellas.typing._data_type import DataTypes as _DataTypes
-from portabellas.typing._data_type import _from_polars_data_type
+from portabellas.typing._data_type import DataTypes, _from_polars_data_type
 
 if TYPE_CHECKING:
     from portabellas import Table
@@ -24,7 +23,7 @@ if TYPE_CHECKING:
 import polars as pl
 from polars.exceptions import InvalidOperationError
 
-_UNKNOWN = _DataTypes.Unknown()
+_UNKNOWN = DataTypes.Unknown()
 
 
 class Column[T_co](Sequence[T_co]):
@@ -87,13 +86,13 @@ class Column[T_co](Sequence[T_co]):
         result.__series_cache = None
         result._lazy_frame = data.select(name)
 
-        if not isinstance(type, _DataTypes.Unknown):
+        if not isinstance(type, DataTypes.Unknown):
             result.__type_cache = type
 
             if "PYTEST_CURRENT_TEST" in os.environ:
                 schema = safely_collect_lazy_frame_schema(result._lazy_frame)
                 polars_type = _from_polars_data_type(schema.dtypes()[0])
-                if not isinstance(polars_type, (_DataTypes.Null, _DataTypes.Unknown)):
+                if not isinstance(polars_type, (DataTypes.Null, DataTypes.Unknown)):
                     assert polars_type == type, (  # noqa: S101
                         f"Cached type {type} does not match Polars-inferred type {polars_type}"
                     )

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable, Iterator, Sequence
 from typing import TYPE_CHECKING, Literal, cast, overload
 
@@ -11,6 +12,7 @@ from portabellas._validation import (
     check_row_counts_are_equal,
 )
 from portabellas.containers._cell._expr_cell import ExprCell
+from portabellas.typing._data_type import DataTypes as _DataTypes
 from portabellas.typing._data_type import _from_polars_data_type
 
 if TYPE_CHECKING:
@@ -68,21 +70,38 @@ class Column[T_co](Sequence[T_co]):
     # ------------------------------------------------------------------------------------------------------------------
 
     @staticmethod
-    def _from_polars_series(data: pl.Series) -> Column:
+    def _from_polars_series(data: pl.Series, *, type: DataType | None = None) -> Column:  # noqa: A002
         result = object.__new__(Column)
         result._name = data.name
         result.__series_cache = data
         result._lazy_frame = data.to_frame().lazy()
-        result.__type_cache = _from_polars_data_type(data.dtype)
+        result.__type_cache = type if type is not None else _from_polars_data_type(data.dtype)
+
+        if type is not None and "PYTEST_CURRENT_TEST" in os.environ:
+            polars_type = _from_polars_data_type(data.dtype)
+            if not isinstance(polars_type, (_DataTypes.Null, _DataTypes.Unknown)):
+                assert polars_type == type, (  # noqa: S101
+                    f"Cached type {type} does not match Polars-inferred type {polars_type}"
+                )
+
         return result
 
     @staticmethod
-    def _from_polars_lazy_frame(name: str, data: pl.LazyFrame) -> Column:
+    def _from_polars_lazy_frame(name: str, data: pl.LazyFrame, *, type: DataType | None = None) -> Column:  # noqa: A002
         result = object.__new__(Column)
         result._name = name
         result.__series_cache = None
         result._lazy_frame = data.select(name)
-        result.__type_cache = None
+        result.__type_cache = type
+
+        if type is not None and "PYTEST_CURRENT_TEST" in os.environ:
+            schema = safely_collect_lazy_frame_schema(result._lazy_frame)
+            polars_type = _from_polars_data_type(schema.dtypes()[0])
+            if not isinstance(polars_type, (_DataTypes.Null, _DataTypes.Unknown)):
+                assert polars_type == type, (  # noqa: S101
+                    f"Cached type {type} does not match Polars-inferred type {polars_type}"
+                )
+
         return result
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -388,10 +407,13 @@ class Column[T_co](Sequence[T_co]):
         | null  |
         +-------+
         """
-        expression = mapper(ExprCell(pl.col(self.name), type=self.type))._polars_expression.alias(self.name)
+        result_cell = mapper(ExprCell(pl.col(self.name), type=self.type))
+        expression = result_cell._polars_expression.alias(self.name)
         result = self._lazy_frame.with_columns(expression)
 
-        return self._from_polars_lazy_frame(self.name, result)
+        result_type = result_cell._type if not isinstance(result_cell._type, _DataTypes.Unknown) else None
+
+        return self._from_polars_lazy_frame(self.name, result, type=result_type)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Reductions (quantifiers)

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -70,20 +70,12 @@ class Column[T_co](Sequence[T_co]):
     # ------------------------------------------------------------------------------------------------------------------
 
     @staticmethod
-    def _from_polars_series(data: pl.Series, *, type: DataType | None = None) -> Column:  # noqa: A002
+    def _from_polars_series(data: pl.Series) -> Column:
         result = object.__new__(Column)
         result._name = data.name
         result.__series_cache = data
         result._lazy_frame = data.to_frame().lazy()
-        result.__type_cache = type if type is not None else _from_polars_data_type(data.dtype)
-
-        if type is not None and "PYTEST_CURRENT_TEST" in os.environ:
-            polars_type = _from_polars_data_type(data.dtype)
-            if not isinstance(polars_type, (_DataTypes.Null, _DataTypes.Unknown)):
-                assert polars_type == type, (  # noqa: S101
-                    f"Cached type {type} does not match Polars-inferred type {polars_type}"
-                )
-
+        result.__type_cache = _from_polars_data_type(data.dtype)
         return result
 
     @staticmethod

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -86,18 +86,11 @@ class Column[T_co](Sequence[T_co]):
         result.__series_cache = None
         result._lazy_frame = data.select(name)
 
-        if not isinstance(type, DataTypes.Unknown):
-            result.__type_cache = type
-
-            if "PYTEST_CURRENT_TEST" in os.environ:
-                schema = safely_collect_lazy_frame_schema(result._lazy_frame)
-                polars_type = _from_polars_data_type(schema.dtypes()[0])
-                if not isinstance(polars_type, (DataTypes.Null, DataTypes.Unknown)):
-                    assert polars_type == type, (  # noqa: S101
-                        f"Cached type {type} does not match Polars-inferred type {polars_type}"
-                    )
-        else:
+        if isinstance(type, DataTypes.Unknown):
             result.__type_cache = None
+        else:
+            result.__type_cache = type
+            Column._cross_check_type(result._lazy_frame, type)
 
         return result
 
@@ -1177,3 +1170,21 @@ class Column[T_co](Sequence[T_co]):
             The generated HTML.
         """
         return self._series._repr_html_()
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------------------------------------------------------
+
+    @staticmethod
+    def _cross_check_type(lazy_frame: pl.LazyFrame, type: DataType) -> None:  # noqa: A002
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            return
+
+        schema = safely_collect_lazy_frame_schema(lazy_frame)
+        polars_type = _from_polars_data_type(schema.dtypes()[0])
+        if isinstance(polars_type, (DataTypes.Null, DataTypes.Unknown)):
+            return
+
+        assert polars_type == type, (  # noqa: S101
+            f"Cached type {type} does not match Polars-inferred type {polars_type}"
+        )

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -84,15 +84,19 @@ class Column[T_co](Sequence[T_co]):
         result._name = name
         result.__series_cache = None
         result._lazy_frame = data.select(name)
-        result.__type_cache = type
 
-        if type is not None and "PYTEST_CURRENT_TEST" in os.environ:
-            schema = safely_collect_lazy_frame_schema(result._lazy_frame)
-            polars_type = _from_polars_data_type(schema.dtypes()[0])
-            if not isinstance(polars_type, (_DataTypes.Null, _DataTypes.Unknown)):
-                assert polars_type == type, (  # noqa: S101
-                    f"Cached type {type} does not match Polars-inferred type {polars_type}"
-                )
+        if type is not None and not isinstance(type, _DataTypes.Unknown):
+            result.__type_cache = type
+
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                schema = safely_collect_lazy_frame_schema(result._lazy_frame)
+                polars_type = _from_polars_data_type(schema.dtypes()[0])
+                if not isinstance(polars_type, (_DataTypes.Null, _DataTypes.Unknown)):
+                    assert polars_type == type, (  # noqa: S101
+                        f"Cached type {type} does not match Polars-inferred type {polars_type}"
+                    )
+        else:
+            result.__type_cache = None
 
         return result
 
@@ -403,9 +407,7 @@ class Column[T_co](Sequence[T_co]):
         expression = result_cell._polars_expression.alias(self.name)
         result = self._lazy_frame.with_columns(expression)
 
-        result_type = result_cell._type if not isinstance(result_cell._type, _DataTypes.Unknown) else None
-
-        return self._from_polars_lazy_frame(self.name, result, type=result_type)
+        return self._from_polars_lazy_frame(self.name, result, type=result_cell._type)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Reductions (quantifiers)

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -188,20 +188,11 @@ class Table:
         result.__data_frame_cache = None
         result._lazy_frame = data
 
-        if schema is not None and any(isinstance(t, DataTypes.Unknown) for t in schema.values()):
+        if schema is None or any(isinstance(t, DataTypes.Unknown) for t in schema.values()):
             result.__schema_cache = None
         else:
             result.__schema_cache = schema
-
-        if result.__schema_cache is not None and "PYTEST_CURRENT_TEST" in os.environ:
-            polars_schema = safely_collect_lazy_frame_schema(result._lazy_frame)
-            for name, cached_type in result.__schema_cache.items():
-                if isinstance(cached_type, (DataTypes.Null, DataTypes.Unknown)):
-                    continue
-                polars_type = _from_polars_data_type(polars_schema[name])
-                assert polars_type == cached_type, (  # noqa: S101
-                    f"Cached type {cached_type} for column '{name}' does not match Polars-inferred type {polars_type}"
-                )
+            Table._cross_check_schema(result._lazy_frame, result.__schema_cache)
 
         return result
 
@@ -1879,6 +1870,24 @@ class Table:
             The generated HTML.
         """
         return self._data_frame._repr_html_()
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------------------------------------------------------
+
+    @staticmethod
+    def _cross_check_schema(lazy_frame: pl.LazyFrame, schema: Schema | None) -> None:
+        if schema is None or "PYTEST_CURRENT_TEST" not in os.environ:
+            return
+
+        polars_schema = safely_collect_lazy_frame_schema(lazy_frame)
+        for name, cached_type in schema.items():
+            if isinstance(cached_type, (DataTypes.Null, DataTypes.Unknown)):
+                continue
+            polars_type = _from_polars_data_type(polars_schema[name])
+            assert polars_type == cached_type, (  # noqa: S101
+                f"Cached type {cached_type} for column '{name}' does not match Polars-inferred type {polars_type}"
+            )
 
 
 def _build_schema_with_new_column(schema: Schema, name: str, type: DataType) -> Schema:  # noqa: A002

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -657,9 +657,7 @@ class Table:
         """
         check_columns_exist(self, name)
 
-        column_type = self.schema.get_column_type(name) if self.__schema_cache is not None else DataTypes.Unknown()
-
-        return Column._from_polars_lazy_frame(name, self._lazy_frame.select(name), type=column_type)
+        return Column._from_polars_lazy_frame(name, self._lazy_frame.select(name))
 
     def get_column_type(self, name: str) -> DataType:
         """
@@ -1842,14 +1840,7 @@ class Table:
         >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
         >>> columns = table.to_columns()
         """
-        return [
-            Column._from_polars_lazy_frame(
-                name,
-                self._lazy_frame,
-                type=self.schema.get_column_type(name) if self.__schema_cache is not None else DataTypes.Unknown(),
-            )
-            for name in self.column_names
-        ]
+        return [Column._from_polars_lazy_frame(name, self._lazy_frame) for name in self.column_names]
 
     def to_dict(self) -> dict[str, list[object]]:
         """

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -21,6 +21,7 @@ from portabellas.containers._row import ExprRow
 from portabellas.exceptions import DuplicateColumnError, LengthMismatchError
 from portabellas.io import TableReader, TableWriter
 from portabellas.typing import Schema
+from portabellas.typing._data_type import DataTypes as _DataTypes
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -29,6 +30,21 @@ if TYPE_CHECKING:
     from portabellas.containers import Cell, Row
     from portabellas.plotting import TablePlotter
     from portabellas.typing import DataType
+
+
+from portabellas.typing import DataType
+
+
+def _build_schema_with_new_column(schema: Schema, name: str, type: DataType) -> Schema:  # noqa: A002
+    new_entries = dict(schema.to_dict())
+    new_entries[name] = type
+    return Schema(new_entries)
+
+
+def _build_schema_with_new_columns(schema: Schema, new_columns: dict[str, DataType]) -> Schema:
+    new_entries = dict(schema.to_dict())
+    new_entries.update(new_columns)
+    return Schema(new_entries)
 
 
 class Table:
@@ -178,11 +194,11 @@ class Table:
         return result
 
     @staticmethod
-    def _from_polars_lazy_frame(data: pl.LazyFrame) -> Table:
+    def _from_polars_lazy_frame(data: pl.LazyFrame, *, schema: Schema | None = None) -> Table:
         result = object.__new__(Table)
         result.__data_frame_cache = None
         result._lazy_frame = data
-        result.__schema_cache = None
+        result.__schema_cache = schema
         return result
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -481,8 +497,14 @@ class Table:
 
         computed_column = mapper(ExprRow(self))
 
+        result_type = computed_column._type if not isinstance(computed_column._type, _DataTypes.Unknown) else None
+        result_schema = (
+            _build_schema_with_new_column(self.schema, name, result_type) if result_type is not None else None
+        )
+
         return self._from_polars_lazy_frame(
             self._lazy_frame.with_columns(computed_column._polars_expression.alias(name)),
+            schema=result_schema,
         )
 
     def add_computed_columns(
@@ -541,10 +563,17 @@ class Table:
             return self.add_columns([Column(name, []) for name in mappers])
 
         expr_row = ExprRow(self)
-        expressions = [mapper(expr_row)._polars_expression.alias(name) for name, mapper in mappers.items()]
+        result_cells = {name: mapper(expr_row) for name, mapper in mappers.items()}
+        expressions = [cell._polars_expression.alias(name) for name, cell in result_cells.items()]
+
+        new_column_types = {
+            name: cell._type for name, cell in result_cells.items() if not isinstance(cell._type, _DataTypes.Unknown)
+        }
+        result_schema = _build_schema_with_new_columns(self.schema, new_column_types) if new_column_types else None
 
         return self._from_polars_lazy_frame(
             self._lazy_frame.with_columns(expressions),
+            schema=result_schema,
         )
 
     def add_index_column(self, name: str, *, first_index: int = 0) -> Table:
@@ -630,7 +659,9 @@ class Table:
         """
         check_columns_exist(self, name)
 
-        return Column._from_polars_lazy_frame(name, self._lazy_frame.select(name))
+        column_type = self.schema.get_column_type(name) if self.__schema_cache is not None else None
+
+        return Column._from_polars_lazy_frame(name, self._lazy_frame.select(name), type=column_type)
 
     def get_column_type(self, name: str) -> DataType:
         """
@@ -1813,7 +1844,14 @@ class Table:
         >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
         >>> columns = table.to_columns()
         """
-        return [Column._from_polars_lazy_frame(name, self._lazy_frame) for name in self.column_names]
+        return [
+            Column._from_polars_lazy_frame(
+                name,
+                self._lazy_frame,
+                type=self.schema.get_column_type(name) if self.__schema_cache is not None else None,
+            )
+            for name in self.column_names
+        ]
 
     def to_dict(self) -> dict[str, list[object]]:
         """

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1878,7 +1878,7 @@ class Table:
     @staticmethod
     def _cross_check_schema(lazy_frame: pl.LazyFrame, schema: Schema | None) -> None:
         if schema is None or "PYTEST_CURRENT_TEST" not in os.environ:
-            return
+            return  # pragma: no cover
 
         polars_schema = safely_collect_lazy_frame_schema(lazy_frame)
         for name, cached_type in schema.items():

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, overload
 
 import polars as pl
@@ -33,18 +34,6 @@ if TYPE_CHECKING:
 
 
 from portabellas.typing import DataType
-
-
-def _build_schema_with_new_column(schema: Schema, name: str, type: DataType) -> Schema:  # noqa: A002
-    new_entries = dict(schema.to_dict())
-    new_entries[name] = type
-    return Schema(new_entries)
-
-
-def _build_schema_with_new_columns(schema: Schema, new_columns: dict[str, DataType]) -> Schema:
-    new_entries = dict(schema.to_dict())
-    new_entries.update(new_columns)
-    return Schema(new_entries)
 
 
 class Table:
@@ -199,6 +188,13 @@ class Table:
         result.__data_frame_cache = None
         result._lazy_frame = data
         result.__schema_cache = schema
+
+        if schema is not None and "PYTEST_CURRENT_TEST" in os.environ:
+            polars_schema = safely_collect_lazy_frame_schema(result._lazy_frame)
+            assert schema == Schema._from_polars_schema(polars_schema), (  # noqa: S101
+                "Cached schema does not match Polars-inferred schema"
+            )
+
         return result
 
     # ------------------------------------------------------------------------------------------------------------------
@@ -1889,3 +1885,15 @@ class Table:
             The generated HTML.
         """
         return self._data_frame._repr_html_()
+
+
+def _build_schema_with_new_column(schema: Schema, name: str, type: DataType) -> Schema:  # noqa: A002
+    new_entries = dict(schema.to_dict())
+    new_entries[name] = type
+    return Schema(new_entries)
+
+
+def _build_schema_with_new_columns(schema: Schema, new_columns: dict[str, DataType]) -> Schema:
+    new_entries = dict(schema.to_dict())
+    new_entries.update(new_columns)
+    return Schema(new_entries)

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -493,9 +493,11 @@ class Table:
 
         computed_column = mapper(ExprRow(self))
 
-        result_type = computed_column._type if not isinstance(computed_column._type, _DataTypes.Unknown) else None
+        result_type = computed_column._type
         result_schema = (
-            _build_schema_with_new_column(self.schema, name, result_type) if result_type is not None else None
+            _build_schema_with_new_column(self.schema, name, result_type)
+            if not isinstance(result_type, _DataTypes.Unknown)
+            else None
         )
 
         return self._from_polars_lazy_frame(

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -22,7 +22,7 @@ from portabellas.containers._row import ExprRow
 from portabellas.exceptions import DuplicateColumnError, LengthMismatchError
 from portabellas.io import TableReader, TableWriter
 from portabellas.typing import Schema
-from portabellas.typing._data_type import DataTypes
+from portabellas.typing._data_type import DataTypes, _from_polars_data_type
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -187,13 +187,21 @@ class Table:
         result = object.__new__(Table)
         result.__data_frame_cache = None
         result._lazy_frame = data
-        result.__schema_cache = schema
 
-        if schema is not None and "PYTEST_CURRENT_TEST" in os.environ:
+        if schema is not None and any(isinstance(t, DataTypes.Unknown) for t in schema.values()):
+            result.__schema_cache = None
+        else:
+            result.__schema_cache = schema
+
+        if result.__schema_cache is not None and "PYTEST_CURRENT_TEST" in os.environ:
             polars_schema = safely_collect_lazy_frame_schema(result._lazy_frame)
-            assert schema == Schema._from_polars_schema(polars_schema), (  # noqa: S101
-                "Cached schema does not match Polars-inferred schema"
-            )
+            for name, cached_type in result.__schema_cache.items():
+                if isinstance(cached_type, (DataTypes.Null, DataTypes.Unknown)):
+                    continue
+                polars_type = _from_polars_data_type(polars_schema[name])
+                assert polars_type == cached_type, (  # noqa: S101
+                    f"Cached type {cached_type} for column '{name}' does not match Polars-inferred type {polars_type}"
+                )
 
         return result
 
@@ -493,12 +501,7 @@ class Table:
 
         computed_column = mapper(ExprRow(self))
 
-        result_type = computed_column._type
-        result_schema = (
-            _build_schema_with_new_column(self.schema, name, result_type)
-            if not isinstance(result_type, DataTypes.Unknown)
-            else None
-        )
+        result_schema = _build_schema_with_new_column(self.schema, name, computed_column._type)
 
         return self._from_polars_lazy_frame(
             self._lazy_frame.with_columns(computed_column._polars_expression.alias(name)),
@@ -564,10 +567,8 @@ class Table:
         result_cells = {name: mapper(expr_row) for name, mapper in mappers.items()}
         expressions = [cell._polars_expression.alias(name) for name, cell in result_cells.items()]
 
-        new_column_types = {
-            name: cell._type for name, cell in result_cells.items() if not isinstance(cell._type, DataTypes.Unknown)
-        }
-        result_schema = _build_schema_with_new_columns(self.schema, new_column_types) if new_column_types else None
+        new_column_types = {name: cell._type for name, cell in result_cells.items()}
+        result_schema = _build_schema_with_new_columns(self.schema, new_column_types)
 
         return self._from_polars_lazy_frame(
             self._lazy_frame.with_columns(expressions),

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -657,7 +657,7 @@ class Table:
         """
         check_columns_exist(self, name)
 
-        column_type = self.schema.get_column_type(name) if self.__schema_cache is not None else None
+        column_type = self.schema.get_column_type(name) if self.__schema_cache is not None else _DataTypes.Unknown()
 
         return Column._from_polars_lazy_frame(name, self._lazy_frame.select(name), type=column_type)
 
@@ -1846,7 +1846,7 @@ class Table:
             Column._from_polars_lazy_frame(
                 name,
                 self._lazy_frame,
-                type=self.schema.get_column_type(name) if self.__schema_cache is not None else None,
+                type=self.schema.get_column_type(name) if self.__schema_cache is not None else _DataTypes.Unknown(),
             )
             for name in self.column_names
         ]

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -22,7 +22,7 @@ from portabellas.containers._row import ExprRow
 from portabellas.exceptions import DuplicateColumnError, LengthMismatchError
 from portabellas.io import TableReader, TableWriter
 from portabellas.typing import Schema
-from portabellas.typing._data_type import DataTypes as _DataTypes
+from portabellas.typing._data_type import DataTypes
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -496,7 +496,7 @@ class Table:
         result_type = computed_column._type
         result_schema = (
             _build_schema_with_new_column(self.schema, name, result_type)
-            if not isinstance(result_type, _DataTypes.Unknown)
+            if not isinstance(result_type, DataTypes.Unknown)
             else None
         )
 
@@ -565,7 +565,7 @@ class Table:
         expressions = [cell._polars_expression.alias(name) for name, cell in result_cells.items()]
 
         new_column_types = {
-            name: cell._type for name, cell in result_cells.items() if not isinstance(cell._type, _DataTypes.Unknown)
+            name: cell._type for name, cell in result_cells.items() if not isinstance(cell._type, DataTypes.Unknown)
         }
         result_schema = _build_schema_with_new_columns(self.schema, new_column_types) if new_column_types else None
 
@@ -657,7 +657,7 @@ class Table:
         """
         check_columns_exist(self, name)
 
-        column_type = self.schema.get_column_type(name) if self.__schema_cache is not None else _DataTypes.Unknown()
+        column_type = self.schema.get_column_type(name) if self.__schema_cache is not None else DataTypes.Unknown()
 
         return Column._from_polars_lazy_frame(name, self._lazy_frame.select(name), type=column_type)
 
@@ -1846,7 +1846,7 @@ class Table:
             Column._from_polars_lazy_frame(
                 name,
                 self._lazy_frame,
-                type=self.schema.get_column_type(name) if self.__schema_cache is not None else _DataTypes.Unknown(),
+                type=self.schema.get_column_type(name) if self.__schema_cache is not None else DataTypes.Unknown(),
             )
             for name in self.column_names
         ]

--- a/tests/portabellas/containers/_column/test_from_lazy_frame.py
+++ b/tests/portabellas/containers/_column/test_from_lazy_frame.py
@@ -32,3 +32,15 @@ def test_should_store_the_data(frame: pl.LazyFrame, expected: list) -> None:
 def test_should_have_correct_type() -> None:
     frame = pl.LazyFrame({"col1": [1]})
     assert Column._from_polars_lazy_frame("col1", frame).type == DataTypes.Int64()
+
+
+def test_should_seed_type_cache_from_type_parameter() -> None:
+    frame = pl.LazyFrame({"col1": [1, 2, 3]})
+    result = Column._from_polars_lazy_frame("col1", frame, type=DataTypes.Int64())
+    assert result.type == DataTypes.Int64()
+
+
+def test_should_raise_on_type_mismatch_in_pytest() -> None:
+    frame = pl.LazyFrame({"col1": [1, 2, 3]})
+    with pytest.raises(AssertionError, match="type"):
+        Column._from_polars_lazy_frame("col1", frame, type=DataTypes.String())

--- a/tests/portabellas/containers/_column/test_from_lazy_frame.py
+++ b/tests/portabellas/containers/_column/test_from_lazy_frame.py
@@ -40,6 +40,12 @@ def test_should_seed_type_cache_from_type_parameter() -> None:
     assert result.type == DataTypes.Int64()
 
 
+def test_should_not_seed_type_cache_for_unknown_type() -> None:
+    frame = pl.LazyFrame({"col1": [1, 2, 3]})
+    result = Column._from_polars_lazy_frame("col1", frame, type=DataTypes.Unknown())
+    assert result.type == DataTypes.Int64()
+
+
 def test_should_raise_on_type_mismatch_in_pytest() -> None:
     frame = pl.LazyFrame({"col1": [1, 2, 3]})
     with pytest.raises(AssertionError, match="type"):

--- a/tests/portabellas/containers/_column/test_from_polars_series.py
+++ b/tests/portabellas/containers/_column/test_from_polars_series.py
@@ -2,7 +2,7 @@ import polars as pl
 import pytest
 
 from portabellas import Column
-from portabellas.typing import DataTypes
+from portabellas.typing import DataType, DataTypes
 
 
 def test_should_store_the_name() -> None:
@@ -32,3 +32,15 @@ def test_should_store_the_data(series: pl.Series, expected: list) -> None:
 def test_should_have_correct_type() -> None:
     series = pl.Series("col1", [1])
     assert Column._from_polars_series(series).type == DataTypes.Int64()
+
+
+@pytest.mark.parametrize(
+    ("type_", "expected"),
+    [
+        pytest.param(DataTypes.Int64(), DataTypes.Int64(), id="matching type"),
+    ],
+)
+def test_should_use_provided_type_over_polars_dtype(type_: DataType, expected: DataType) -> None:
+    series = pl.Series("col1", [1, 2, 3])
+    result = Column._from_polars_series(series, type=type_)
+    assert result.type == expected

--- a/tests/portabellas/containers/_column/test_from_polars_series.py
+++ b/tests/portabellas/containers/_column/test_from_polars_series.py
@@ -2,7 +2,7 @@ import polars as pl
 import pytest
 
 from portabellas import Column
-from portabellas.typing import DataType, DataTypes
+from portabellas.typing import DataTypes
 
 
 def test_should_store_the_name() -> None:
@@ -32,15 +32,3 @@ def test_should_store_the_data(series: pl.Series, expected: list) -> None:
 def test_should_have_correct_type() -> None:
     series = pl.Series("col1", [1])
     assert Column._from_polars_series(series).type == DataTypes.Int64()
-
-
-@pytest.mark.parametrize(
-    ("type_", "expected"),
-    [
-        pytest.param(DataTypes.Int64(), DataTypes.Int64(), id="matching type"),
-    ],
-)
-def test_should_use_provided_type_over_polars_dtype(type_: DataType, expected: DataType) -> None:
-    series = pl.Series("col1", [1, 2, 3])
-    result = Column._from_polars_series(series, type=type_)
-    assert result.type == expected

--- a/tests/portabellas/containers/_column/test_map.py
+++ b/tests/portabellas/containers/_column/test_map.py
@@ -4,6 +4,7 @@ import pytest
 
 from portabellas import Column
 from portabellas.containers import Cell
+from portabellas.containers._cell._expr_cell import ExprCell
 from portabellas.typing import DataTypes
 from tests.helpers import assert_cell_has_type
 
@@ -60,3 +61,19 @@ def test_should_pass_column_type_to_mapper() -> None:
         return Cell.constant(1)
 
     Column("a", [1, 2, 3]).map(capture)
+
+
+def test_should_propagate_known_type_from_mapper() -> None:
+    column = Column("a", [1, 2, 3])
+    result = column.map(lambda cell: cell < 2)
+    assert result.type == DataTypes.Boolean()
+
+
+def test_should_fall_back_to_polars_when_mapper_returns_unknown_type() -> None:
+    column = Column("a", [1, 2, 3])
+
+    def mapper(cell: Cell) -> Cell:
+        return ExprCell(cell._polars_expression < 2, type=DataTypes.Unknown())
+
+    result = column.map(mapper)
+    assert result.type == DataTypes.Boolean()

--- a/tests/portabellas/containers/_table/test_add_computed_column.py
+++ b/tests/portabellas/containers/_table/test_add_computed_column.py
@@ -3,8 +3,10 @@ from collections.abc import Callable
 import pytest
 
 from portabellas import Table
-from portabellas.containers import Cell
+from portabellas.containers import Cell, Row
+from portabellas.containers._cell._expr_cell import ExprCell
 from portabellas.exceptions import DuplicateColumnError
+from portabellas.typing import DataTypes
 from tests.helpers import assert_tables_are_equal
 
 
@@ -67,3 +69,20 @@ class TestHappyPath:
 def test_should_raise_if_duplicate_column_name() -> None:
     with pytest.raises(DuplicateColumnError):
         Table({"col1": []}).add_computed_column("col1", lambda row: row["col1"])
+
+
+def test_should_propagate_known_type_from_mapper() -> None:
+    table = Table({"a": [1, 2, 3]})
+    result = table.add_computed_column("b", lambda row: row["a"] < 2)
+    assert result.get_column_type("b") == DataTypes.Boolean()
+
+
+def test_should_fall_back_to_polars_when_mapper_returns_unknown_type() -> None:
+    table = Table({"a": [1, 2, 3]})
+
+    def mapper(row: Row) -> Cell:
+        cell = row["a"]
+        return ExprCell(cell._polars_expression < 2, type=DataTypes.Unknown())
+
+    result = table.add_computed_column("b", mapper)
+    assert result.get_column_type("b") == DataTypes.Boolean()

--- a/tests/portabellas/containers/_table/test_add_computed_columns.py
+++ b/tests/portabellas/containers/_table/test_add_computed_columns.py
@@ -3,8 +3,10 @@ from collections.abc import Callable
 import pytest
 
 from portabellas import Table
-from portabellas.containers import Cell
+from portabellas.containers import Cell, Row
+from portabellas.containers._cell._expr_cell import ExprCell
 from portabellas.exceptions import DuplicateColumnError
+from portabellas.typing import DataTypes
 from tests.helpers import assert_tables_are_equal
 
 
@@ -86,3 +88,23 @@ def test_should_raise_if_new_name_clashes_with_existing() -> None:
         Table({"a": [1], "b": [2]}).add_computed_columns(
             {"a": lambda row: row["b"], "c": lambda row: row["a"]},
         )
+
+
+def test_should_propagate_known_types_from_mappers() -> None:
+    table = Table({"a": [1, 2, 3]})
+    result = table.add_computed_columns(
+        {"b": lambda row: row["a"] < 2, "c": lambda row: row["a"] + 10},
+    )
+    assert result.get_column_type("b") == DataTypes.Boolean()
+    assert result.get_column_type("c") == DataTypes.Int64()
+
+
+def test_should_fall_back_to_polars_when_mapper_returns_unknown_type() -> None:
+    table = Table({"a": [1, 2, 3]})
+
+    def mapper(row: Row) -> Cell:
+        cell = row["a"]
+        return ExprCell(cell._polars_expression < 2, type=DataTypes.Unknown())
+
+    result = table.add_computed_columns({"b": mapper})
+    assert result.get_column_type("b") == DataTypes.Boolean()

--- a/tests/portabellas/containers/_table/test_from_polars_lazy_frame.py
+++ b/tests/portabellas/containers/_table/test_from_polars_lazy_frame.py
@@ -4,6 +4,7 @@ import polars as pl
 import pytest
 
 from portabellas import Table
+from portabellas.typing import DataTypes, Schema
 from tests.helpers import assert_tables_are_equal
 
 
@@ -19,3 +20,17 @@ def test_should_create_table(data: dict[str, list[Any]]) -> None:
     actual = Table._from_polars_lazy_frame(pl.LazyFrame(data))
     expected = Table(data)
     assert_tables_are_equal(actual, expected)
+
+
+def test_should_seed_schema_cache_from_schema_parameter() -> None:
+    data = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    schema = Schema({"a": DataTypes.Int64(), "b": DataTypes.Int64()})
+    result = Table._from_polars_lazy_frame(data, schema=schema)
+    assert result.schema == schema
+
+
+def test_should_raise_on_schema_mismatch_in_pytest() -> None:
+    data = pl.LazyFrame({"a": [1, 2, 3]})
+    wrong_schema = Schema({"a": DataTypes.String()})
+    with pytest.raises(AssertionError, match="schema"):
+        Table._from_polars_lazy_frame(data, schema=wrong_schema)

--- a/tests/portabellas/containers/_table/test_from_polars_lazy_frame.py
+++ b/tests/portabellas/containers/_table/test_from_polars_lazy_frame.py
@@ -29,8 +29,15 @@ def test_should_seed_schema_cache_from_schema_parameter() -> None:
     assert result.schema == schema
 
 
+def test_should_not_seed_schema_cache_if_any_column_has_unknown_type() -> None:
+    data = pl.LazyFrame({"a": [1, 2, 3]})
+    schema = Schema({"a": DataTypes.Unknown()})
+    result = Table._from_polars_lazy_frame(data, schema=schema)
+    assert result.schema == Schema({"a": DataTypes.Int64()})
+
+
 def test_should_raise_on_schema_mismatch_in_pytest() -> None:
     data = pl.LazyFrame({"a": [1, 2, 3]})
     wrong_schema = Schema({"a": DataTypes.String()})
-    with pytest.raises(AssertionError, match="schema"):
+    with pytest.raises(AssertionError, match="column"):
         Table._from_polars_lazy_frame(data, schema=wrong_schema)


### PR DESCRIPTION
Closes #134

### Summary of Changes

- Propagate known `ExprCell._type` to `Column.__type_cache` and `Table.__schema_cache` via new `type`/`schema` keyword parameters on the internal factory methods, with a pytest-guarded cross-check that validates the cached type against the Polars-inferred type at construction time to catch inference regressions with zero production overhead.
