### PR TITLE
feat(containers): add integer bitwise operations to Cell API

### DIFF
--- a/src/portabellas/_validation/_cell_type_requirements.py
+++ b/src/portabellas/_validation/_cell_type_requirements.py
@@ -11,6 +11,7 @@ class CellTypeRequirements:
     DATETIME_OR_TIME = InstanceOf(DataTypes.Datetime, DataTypes.Time)
     DT = InstanceOf(DataTypes.Date, DataTypes.Datetime, DataTypes.Time)
     DURATION = InstanceOf(DataTypes.Duration)
+    INTEGER = CellTypeRequirement("integer", lambda t: t.is_int)
     LIST = CellTypeRequirement("list", lambda t: t.is_list)
     NUMERIC = CellTypeRequirement("numeric", lambda t: t.is_numeric)
     NUMERIC_OR_BOOLEAN = CellTypeRequirement(

--- a/src/portabellas/containers/_cell/__init__.py
+++ b/src/portabellas/containers/_cell/__init__.py
@@ -1,5 +1,6 @@
 from ._cell import (
     Cell,
+    ConvertibleToBitwiseCell,
     ConvertibleToBooleanCell,
     ConvertibleToCell,
     ConvertibleToIntCell,
@@ -10,6 +11,7 @@ from ._expr_cell import ExprCell
 
 __all__ = [
     "Cell",
+    "ConvertibleToBitwiseCell",
     "ConvertibleToBooleanCell",
     "ConvertibleToCell",
     "ConvertibleToIntCell",

--- a/src/portabellas/containers/_cell/_cell.py
+++ b/src/portabellas/containers/_cell/_cell.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 
 type ConvertibleToCell = int | float | Decimal | date | time | datetime | timedelta | bool | str | bytes | Cell | None
+type ConvertibleToBitwiseCell = bool | int | Cell | None
 type ConvertibleToBooleanCell = bool | Cell | None
 type ConvertibleToIntCell = int | Cell | None
 type ConvertibleToNumericCell = int | float | Cell | None
@@ -486,22 +487,22 @@ class Cell(ABC):
     def __invert__(self) -> Cell: ...
 
     @abstractmethod
-    def __and__(self, other: ConvertibleToBooleanCell) -> Cell: ...
+    def __and__(self, other: ConvertibleToBitwiseCell) -> Cell: ...
 
     @abstractmethod
-    def __rand__(self, other: ConvertibleToBooleanCell) -> Cell: ...
+    def __rand__(self, other: ConvertibleToBitwiseCell) -> Cell: ...
 
     @abstractmethod
-    def __or__(self, other: ConvertibleToBooleanCell) -> Cell: ...
+    def __or__(self, other: ConvertibleToBitwiseCell) -> Cell: ...
 
     @abstractmethod
-    def __ror__(self, other: ConvertibleToBooleanCell) -> Cell: ...
+    def __ror__(self, other: ConvertibleToBitwiseCell) -> Cell: ...
 
     @abstractmethod
-    def __xor__(self, other: ConvertibleToBooleanCell) -> Cell: ...
+    def __xor__(self, other: ConvertibleToBitwiseCell) -> Cell: ...
 
     @abstractmethod
-    def __rxor__(self, other: ConvertibleToBooleanCell) -> Cell: ...
+    def __rxor__(self, other: ConvertibleToBitwiseCell) -> Cell: ...
 
     # Comparison ---------------------------------------------------------------
 
@@ -769,6 +770,173 @@ class Cell(ABC):
         +-------+
         """
         return self.__xor__(other)
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Bitwise operations
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def bitwise_and(self, other: ConvertibleToIntCell) -> Cell:
+        """
+        Perform a bitwise AND operation. This is equivalent to the `&` operator on integers.
+
+        Parameters
+        ----------
+        other:
+            The right operand.
+
+        Returns
+        -------
+        cell:
+            The result of the bitwise AND.
+
+        Examples
+        --------
+        >>> from portabellas import Column
+        >>> column = Column("a", [0b1100, 0b1010, None])
+        >>> column.map(lambda cell: cell.bitwise_and(0b1010))
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |    8 |
+        |   10 |
+        | null |
+        +------+
+
+        >>> column.map(lambda cell: cell & 0b1010)
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |    8 |
+        |   10 |
+        | null |
+        +------+
+        """
+        return self.__and__(other)
+
+    def bitwise_or(self, other: ConvertibleToIntCell) -> Cell:
+        """
+        Perform a bitwise OR operation. This is equivalent to the `|` operator on integers.
+
+        Parameters
+        ----------
+        other:
+            The right operand.
+
+        Returns
+        -------
+        cell:
+            The result of the bitwise OR.
+
+        Examples
+        --------
+        >>> from portabellas import Column
+        >>> column = Column("a", [0b1100, 0b1010, None])
+        >>> column.map(lambda cell: cell.bitwise_or(0b1010))
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |   14 |
+        |   10 |
+        | null |
+        +------+
+
+        >>> column.map(lambda cell: cell | 0b1010)
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |   14 |
+        |   10 |
+        | null |
+        +------+
+        """
+        return self.__or__(other)
+
+    def bitwise_xor(self, other: ConvertibleToIntCell) -> Cell:
+        """
+        Perform a bitwise XOR operation. This is equivalent to the `^` operator on integers.
+
+        Parameters
+        ----------
+        other:
+            The right operand.
+
+        Returns
+        -------
+        cell:
+            The result of the bitwise XOR.
+
+        Examples
+        --------
+        >>> from portabellas import Column
+        >>> column = Column("a", [0b1100, 0b1010, None])
+        >>> column.map(lambda cell: cell.bitwise_xor(0b1010))
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |    6 |
+        |    0 |
+        | null |
+        +------+
+
+        >>> column.map(lambda cell: cell ^ 0b1010)
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |    6 |
+        |    0 |
+        | null |
+        +------+
+        """
+        return self.__xor__(other)
+
+    def bitwise_invert(self) -> Cell:
+        """
+        Invert the bits of an integer. This is equivalent to the `~` operator on integers.
+
+        Returns
+        -------
+        cell:
+            The result of the bitwise inversion.
+
+        Examples
+        --------
+        >>> from portabellas import Column
+        >>> column = Column("a", [0, 1, None])
+        >>> column.map(lambda cell: cell.bitwise_invert())
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |   -1 |
+        |   -2 |
+        | null |
+        +------+
+
+        >>> column.map(lambda cell: ~cell)
+        +------+
+        |    a |
+        |  --- |
+        |  i64 |
+        +======+
+        |   -1 |
+        |   -2 |
+        | null |
+        +------+
+        """
+        return self.__invert__()
 
     # ------------------------------------------------------------------------------------------------------------------
     # Numeric operations

--- a/src/portabellas/containers/_cell/_expr_cell.py
+++ b/src/portabellas/containers/_cell/_expr_cell.py
@@ -16,7 +16,14 @@ from portabellas.query._struct_operations import ExprStructOperations
 from portabellas.typing import DataType, DataTypes
 from portabellas.typing._type_inference import infer_operation_type
 
-from ._cell import Cell, ConvertibleToBooleanCell, ConvertibleToCell, _to_polars_expression
+from ._cell import (
+    Cell,
+    ConvertibleToBitwiseCell,
+    ConvertibleToBooleanCell,
+    ConvertibleToCell,
+    ConvertibleToIntCell,
+    _to_polars_expression,
+)
 
 if TYPE_CHECKING:
     from portabellas.query import (
@@ -49,44 +56,89 @@ class ExprCell(Cell):
     # "Boolean" operators (actually bitwise) -----------------------------------
 
     def __invert__(self) -> Cell:
-        check_type(self, required=CellTypeRequirements.BOOLEAN)
-        return ExprCell(self._expression.cast(pl.Boolean).__invert__(), type=_BOOLEAN)
+        if isinstance(self._type, DataTypes.Boolean):
+            return ExprCell(self._expression.cast(pl.Boolean).__invert__(), type=_BOOLEAN)
+        if not isinstance(self._type, (DataTypes.Unknown, DataTypes.Null)):
+            check_type(self, required=CellTypeRequirements.INTEGER)
+        return ExprCell(self._expression.__invert__(), type=self._type)
 
-    def __and__(self, other: ConvertibleToBooleanCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.BOOLEAN)
-        check_type(other, required=CellTypeRequirements.BOOLEAN)
+    def __and__(self, other: ConvertibleToBitwiseCell) -> Cell:
+        if isinstance(self._type, DataTypes.Boolean):
+            check_type(other, required=CellTypeRequirements.BOOLEAN)
+            other_expr = _to_polars_expression(other)
+            return ExprCell(self._expression.__and__(other_expr), type=_BOOLEAN)
+        if not isinstance(self._type, (DataTypes.Unknown, DataTypes.Null)):
+            check_type(self, required=CellTypeRequirements.INTEGER)
+            check_type(other, required=CellTypeRequirements.INTEGER)
+        other_type = _type_or_literal_of_other(other)
+        result_type = infer_operation_type(pl.Expr.__and__, self._type, other_type)
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__and__(other_expr), type=_BOOLEAN)
+        return ExprCell(self._expression.__and__(other_expr), type=result_type)
 
-    def __rand__(self, other: ConvertibleToBooleanCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.BOOLEAN)
-        check_type(other, required=CellTypeRequirements.BOOLEAN)
+    def __rand__(self, other: ConvertibleToBitwiseCell) -> Cell:
+        if isinstance(self._type, DataTypes.Boolean):
+            check_type(other, required=CellTypeRequirements.BOOLEAN)
+            other_expr = _to_polars_expression(other)
+            return ExprCell(self._expression.__rand__(other_expr), type=_BOOLEAN)
+        if not isinstance(self._type, (DataTypes.Unknown, DataTypes.Null)):
+            check_type(self, required=CellTypeRequirements.INTEGER)
+            check_type(other, required=CellTypeRequirements.INTEGER)
+        other_type = _type_or_literal_of_other(other)
+        result_type = infer_operation_type(pl.Expr.__rand__, self._type, other_type)
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__rand__(other_expr), type=_BOOLEAN)
+        return ExprCell(self._expression.__rand__(other_expr), type=result_type)
 
-    def __or__(self, other: ConvertibleToBooleanCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.BOOLEAN)
-        check_type(other, required=CellTypeRequirements.BOOLEAN)
+    def __or__(self, other: ConvertibleToBitwiseCell) -> Cell:
+        if isinstance(self._type, DataTypes.Boolean):
+            check_type(other, required=CellTypeRequirements.BOOLEAN)
+            other_expr = _to_polars_expression(other)
+            return ExprCell(self._expression.__or__(other_expr), type=_BOOLEAN)
+        if not isinstance(self._type, (DataTypes.Unknown, DataTypes.Null)):
+            check_type(self, required=CellTypeRequirements.INTEGER)
+            check_type(other, required=CellTypeRequirements.INTEGER)
+        other_type = _type_or_literal_of_other(other)
+        result_type = infer_operation_type(pl.Expr.__or__, self._type, other_type)
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__or__(other_expr), type=_BOOLEAN)
+        return ExprCell(self._expression.__or__(other_expr), type=result_type)
 
-    def __ror__(self, other: ConvertibleToBooleanCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.BOOLEAN)
-        check_type(other, required=CellTypeRequirements.BOOLEAN)
+    def __ror__(self, other: ConvertibleToBitwiseCell) -> Cell:
+        if isinstance(self._type, DataTypes.Boolean):
+            check_type(other, required=CellTypeRequirements.BOOLEAN)
+            other_expr = _to_polars_expression(other)
+            return ExprCell(self._expression.__ror__(other_expr), type=_BOOLEAN)
+        if not isinstance(self._type, (DataTypes.Unknown, DataTypes.Null)):
+            check_type(self, required=CellTypeRequirements.INTEGER)
+            check_type(other, required=CellTypeRequirements.INTEGER)
+        other_type = _type_or_literal_of_other(other)
+        result_type = infer_operation_type(pl.Expr.__ror__, self._type, other_type)
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__ror__(other_expr), type=_BOOLEAN)
+        return ExprCell(self._expression.__ror__(other_expr), type=result_type)
 
-    def __xor__(self, other: ConvertibleToBooleanCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.BOOLEAN)
-        check_type(other, required=CellTypeRequirements.BOOLEAN)
+    def __xor__(self, other: ConvertibleToBitwiseCell) -> Cell:
+        if isinstance(self._type, DataTypes.Boolean):
+            check_type(other, required=CellTypeRequirements.BOOLEAN)
+            other_expr = _to_polars_expression(other)
+            return ExprCell(self._expression.__xor__(other_expr), type=_BOOLEAN)
+        if not isinstance(self._type, (DataTypes.Unknown, DataTypes.Null)):
+            check_type(self, required=CellTypeRequirements.INTEGER)
+            check_type(other, required=CellTypeRequirements.INTEGER)
+        other_type = _type_or_literal_of_other(other)
+        result_type = infer_operation_type(pl.Expr.__xor__, self._type, other_type)
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__xor__(other_expr), type=_BOOLEAN)
+        return ExprCell(self._expression.__xor__(other_expr), type=result_type)
 
-    def __rxor__(self, other: ConvertibleToBooleanCell) -> Cell:
-        check_type(self, required=CellTypeRequirements.BOOLEAN)
-        check_type(other, required=CellTypeRequirements.BOOLEAN)
+    def __rxor__(self, other: ConvertibleToBitwiseCell) -> Cell:
+        if isinstance(self._type, DataTypes.Boolean):
+            check_type(other, required=CellTypeRequirements.BOOLEAN)
+            other_expr = _to_polars_expression(other)
+            return ExprCell(self._expression.__rxor__(other_expr), type=_BOOLEAN)
+        if not isinstance(self._type, (DataTypes.Unknown, DataTypes.Null)):
+            check_type(self, required=CellTypeRequirements.INTEGER)
+            check_type(other, required=CellTypeRequirements.INTEGER)
+        other_type = _type_or_literal_of_other(other)
+        result_type = infer_operation_type(pl.Expr.__rxor__, self._type, other_type)
         other_expr = _to_polars_expression(other)
-        return ExprCell(self._expression.__rxor__(other_expr), type=_BOOLEAN)
+        return ExprCell(self._expression.__rxor__(other_expr), type=result_type)
 
     # Comparison ---------------------------------------------------------------
 
@@ -261,6 +313,44 @@ class ExprCell(Cell):
     # ------------------------------------------------------------------------------------------------------------------
     # Comparison operations
     # ------------------------------------------------------------------------------------------------------------------
+
+    def not_(self) -> Cell:
+        check_type(self, required=CellTypeRequirements.BOOLEAN)
+        return self.__invert__()
+
+    def and_(self, other: ConvertibleToBooleanCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.BOOLEAN)
+        check_type(other, required=CellTypeRequirements.BOOLEAN)
+        return self.__and__(other)
+
+    def or_(self, other: ConvertibleToBooleanCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.BOOLEAN)
+        check_type(other, required=CellTypeRequirements.BOOLEAN)
+        return self.__or__(other)
+
+    def xor(self, other: ConvertibleToBooleanCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.BOOLEAN)
+        check_type(other, required=CellTypeRequirements.BOOLEAN)
+        return self.__xor__(other)
+
+    def bitwise_and(self, other: ConvertibleToIntCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.INTEGER)
+        check_type(other, required=CellTypeRequirements.INTEGER)
+        return self.__and__(other)
+
+    def bitwise_or(self, other: ConvertibleToIntCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.INTEGER)
+        check_type(other, required=CellTypeRequirements.INTEGER)
+        return self.__or__(other)
+
+    def bitwise_xor(self, other: ConvertibleToIntCell) -> Cell:
+        check_type(self, required=CellTypeRequirements.INTEGER)
+        check_type(other, required=CellTypeRequirements.INTEGER)
+        return self.__xor__(other)
+
+    def bitwise_invert(self) -> Cell:
+        check_type(self, required=CellTypeRequirements.INTEGER)
+        return self.__invert__()
 
     def eq(self, other: object, *, propagate_nulls: bool = False) -> Cell:
         other_expr = _to_polars_expression(other)

--- a/tests/portabellas/containers/_cell/test_and.py
+++ b/tests/portabellas/containers/_cell/test_and.py
@@ -75,31 +75,37 @@ class TestShouldComputeConjunction:
     "cell_type",
     [
         pytest.param(DataTypes.String(), id="string"),
-        pytest.param(DataTypes.Int64(), id="int"),
+        pytest.param(DataTypes.Float64(), id="float"),
     ],
 )
-class TestShouldRaiseForNonBooleanType:
+class TestShouldRaiseForNonBooleanNonIntegerTypeOnOperator:
     def test_self(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
             _ = cell_of_type(cell_type) & True
 
     def test_other_cell(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = cell_of_type(DataTypes.Boolean()) & cell_of_type(cell_type)
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()) & cell_of_type(cell_type)
 
     def test_self_inverted_order(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
             _ = True & cell_of_type(cell_type)
 
 
-class TestShouldRaiseForNonBooleanLiteral:
-    def test_other_literal(self) -> None:
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Int64(), id="int"),
+    ],
+)
+class TestShouldRaiseForNonBooleanTypeOnNamedMethod:
+    def test_self(self, cell_type: DataType) -> None:
         with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = cell_of_type(DataTypes.Boolean()) & 1  # type: ignore[operator]
+            _ = cell_of_type(cell_type).and_(True)  # noqa: FBT003
 
-    def test_other_literal_inverted_order(self) -> None:
+    def test_other_cell(self, cell_type: DataType) -> None:
         with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = 1 & cell_of_type(DataTypes.Boolean())  # type: ignore[operator]
+            _ = cell_of_type(DataTypes.Boolean()).and_(cell_of_type(cell_type))
 
 
 class TestShouldSkipValidationForUnknownType:

--- a/tests/portabellas/containers/_cell/test_bitwise_and.py
+++ b/tests/portabellas/containers/_cell/test_bitwise_and.py
@@ -1,0 +1,143 @@
+from collections.abc import Callable
+from typing import Any
+
+import polars as pl
+import pytest
+
+from portabellas.containers import Cell
+from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+    cell_of_unknown_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("value1", "value2", "expected"),
+    [
+        pytest.param(0b1100, 0b1010, 0b1000, id="1100 - 1010"),
+        pytest.param(0b1100, 0, 0, id="1100 - 0"),
+        pytest.param(0, 0b1010, 0, id="0 - 1010"),
+        pytest.param(0b1111, 0b1111, 0b1111, id="1111 - 1111"),
+        pytest.param(0b1100, None, None, id="1100 - None"),
+        pytest.param(None, 0b1010, None, id="None - 1010"),
+        pytest.param(None, None, None, id="None - None"),
+    ],
+)
+class TestShouldComputeBitwiseAnd:
+    def test_dunder_method(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell & value2, expected, type_if_none=DataTypes.Int64())
+
+    def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell & ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+    def test_dunder_method_inverted_order(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(value2, lambda cell: value1 & cell, expected, type_if_none=DataTypes.Int64())
+
+    def test_dunder_method_inverted_order_wrapped_in_cell(
+        self,
+        value1: Any,
+        value2: int | None,
+        expected: int | None,
+    ) -> None:
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) & cell,
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+    def test_named_method(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1, lambda cell: cell.bitwise_and(value2), expected, type_if_none=DataTypes.Int64()
+        )
+
+    def test_named_method_wrapped_in_cell(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.bitwise_and(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Boolean(), id="boolean"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+class TestShouldRaiseForNonIntegerTypeOnBitwiseAnd:
+    def test_self(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(cell_type).bitwise_and(1)
+
+    def test_other_cell(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()).bitwise_and(cell_of_type(cell_type))
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+class TestShouldRaiseForNonIntegerTypeOnOperator:
+    def test_self(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(cell_type) & 1
+
+    def test_other_cell(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()) & cell_of_type(cell_type)
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self(self) -> None:
+        _ = cell_of_unknown_type() & 1
+
+    def test_other_cell(self) -> None:
+        _ = cell_of_type(DataTypes.Int64()) & cell_of_unknown_type()
+
+    def test_other_literal_none(self) -> None:
+        _ = cell_of_type(DataTypes.Int64()) & None
+
+    def test_self_reflected(self) -> None:
+        _ = 1 & cell_of_unknown_type()
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(DataTypes.Int64(), lambda cell: cell & 1, DataTypes.Int64(), id="__and__"),
+        pytest.param(DataTypes.Int64(), lambda cell: 1 & cell, DataTypes.Int64(), id="__rand__"),
+        pytest.param(DataTypes.Int64(), lambda cell: cell.bitwise_and(1), DataTypes.Int64(), id="bitwise_and"),
+        pytest.param(DataTypes.Int32(), lambda cell: cell & 1, DataTypes.Int32(), id="__and___int32"),
+        pytest.param(DataTypes.UInt32(), lambda cell: cell & 1, DataTypes.UInt32(), id="__and___uint32"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/containers/_cell/test_bitwise_invert.py
+++ b/tests/portabellas/containers/_cell/test_bitwise_invert.py
@@ -1,0 +1,84 @@
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from portabellas.containers import Cell
+from portabellas.exceptions import ColumnTypeError
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+    cell_of_unknown_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(0, -1, id="0"),
+        pytest.param(1, -2, id="1"),
+        pytest.param(-1, 0, id="-1"),
+        pytest.param(None, None, id="None"),
+    ],
+)
+class TestShouldInvertBitsOfCell:
+    def test_dunder_method(self, value: Any, expected: int | None) -> None:
+        assert_cell_operation_works(value, lambda cell: ~cell, expected, type_if_none=DataTypes.Int64())
+
+    def test_named_method(self, value: Any, expected: int | None) -> None:
+        assert_cell_operation_works(value, lambda cell: cell.bitwise_invert(), expected, type_if_none=DataTypes.Int64())
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Boolean(), id="boolean"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+class TestShouldRaiseForNonIntegerTypeOnBitwiseInvert:
+    def test_self(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(cell_type).bitwise_invert()
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+def test_should_raise_for_non_integer_type_on_operator(cell_type: DataType) -> None:
+    with pytest.raises(ColumnTypeError, match="Expected integer type"):
+        _ = ~cell_of_type(cell_type)
+
+
+def test_should_skip_validation_for_unknown_type() -> None:
+    _ = ~cell_of_unknown_type()
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(DataTypes.Int64(), lambda cell: ~cell, DataTypes.Int64(), id="__invert__"),
+        pytest.param(DataTypes.Int64(), lambda cell: cell.bitwise_invert(), DataTypes.Int64(), id="bitwise_invert"),
+        pytest.param(DataTypes.Int32(), lambda cell: ~cell, DataTypes.Int32(), id="__invert___int32"),
+        pytest.param(DataTypes.UInt32(), lambda cell: ~cell, DataTypes.UInt32(), id="__invert___uint32"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/containers/_cell/test_bitwise_or.py
+++ b/tests/portabellas/containers/_cell/test_bitwise_or.py
@@ -1,0 +1,143 @@
+from collections.abc import Callable
+from typing import Any
+
+import polars as pl
+import pytest
+
+from portabellas.containers import Cell
+from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+    cell_of_unknown_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("value1", "value2", "expected"),
+    [
+        pytest.param(0b1100, 0b1010, 0b1110, id="1100 - 1010"),
+        pytest.param(0b1100, 0, 0b1100, id="1100 - 0"),
+        pytest.param(0, 0b1010, 0b1010, id="0 - 1010"),
+        pytest.param(0b1111, 0b1111, 0b1111, id="1111 - 1111"),
+        pytest.param(0b1100, None, None, id="1100 - None"),
+        pytest.param(None, 0b1010, None, id="None - 1010"),
+        pytest.param(None, None, None, id="None - None"),
+    ],
+)
+class TestShouldComputeBitwiseOr:
+    def test_dunder_method(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell | value2, expected, type_if_none=DataTypes.Int64())
+
+    def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell | ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+    def test_dunder_method_inverted_order(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(value2, lambda cell: value1 | cell, expected, type_if_none=DataTypes.Int64())
+
+    def test_dunder_method_inverted_order_wrapped_in_cell(
+        self,
+        value1: Any,
+        value2: int | None,
+        expected: int | None,
+    ) -> None:
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) | cell,
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+    def test_named_method(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1, lambda cell: cell.bitwise_or(value2), expected, type_if_none=DataTypes.Int64()
+        )
+
+    def test_named_method_wrapped_in_cell(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.bitwise_or(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Boolean(), id="boolean"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+class TestShouldRaiseForNonIntegerTypeOnBitwiseOr:
+    def test_self(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(cell_type).bitwise_or(1)
+
+    def test_other_cell(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()).bitwise_or(cell_of_type(cell_type))
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+class TestShouldRaiseForNonIntegerTypeOnOperator:
+    def test_self(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(cell_type) | 1
+
+    def test_other_cell(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()) | cell_of_type(cell_type)
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self(self) -> None:
+        _ = cell_of_unknown_type() | 1
+
+    def test_other_cell(self) -> None:
+        _ = cell_of_type(DataTypes.Int64()) | cell_of_unknown_type()
+
+    def test_other_literal_none(self) -> None:
+        _ = cell_of_type(DataTypes.Int64()) | None
+
+    def test_self_reflected(self) -> None:
+        _ = 1 | cell_of_unknown_type()
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(DataTypes.Int64(), lambda cell: cell | 1, DataTypes.Int64(), id="__or__"),
+        pytest.param(DataTypes.Int64(), lambda cell: 1 | cell, DataTypes.Int64(), id="__ror__"),
+        pytest.param(DataTypes.Int64(), lambda cell: cell.bitwise_or(1), DataTypes.Int64(), id="bitwise_or"),
+        pytest.param(DataTypes.Int32(), lambda cell: cell | 1, DataTypes.Int32(), id="__or___int32"),
+        pytest.param(DataTypes.UInt32(), lambda cell: cell | 1, DataTypes.UInt32(), id="__or___uint32"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/containers/_cell/test_bitwise_xor.py
+++ b/tests/portabellas/containers/_cell/test_bitwise_xor.py
@@ -1,0 +1,143 @@
+from collections.abc import Callable
+from typing import Any
+
+import polars as pl
+import pytest
+
+from portabellas.containers import Cell
+from portabellas.containers._cell import ExprCell
+from portabellas.exceptions import ColumnTypeError
+from portabellas.typing import DataType, DataTypes
+from tests.helpers import (
+    assert_cell_has_type,
+    assert_cell_operation_works,
+    assert_cell_type_matches_polars,
+    cell_of_type,
+    cell_of_unknown_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("value1", "value2", "expected"),
+    [
+        pytest.param(0b1100, 0b1010, 0b0110, id="1100 - 1010"),
+        pytest.param(0b1100, 0, 0b1100, id="1100 - 0"),
+        pytest.param(0, 0b1010, 0b1010, id="0 - 1010"),
+        pytest.param(0b1111, 0b1111, 0, id="1111 - 1111"),
+        pytest.param(0b1100, None, None, id="1100 - None"),
+        pytest.param(None, 0b1010, None, id="None - 1010"),
+        pytest.param(None, None, None, id="None - None"),
+    ],
+)
+class TestShouldComputeBitwiseXor:
+    def test_dunder_method(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(value1, lambda cell: cell ^ value2, expected, type_if_none=DataTypes.Int64())
+
+    def test_dunder_method_wrapped_in_cell(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell ^ ExprCell(pl.lit(value2), type=DataTypes.Unknown()),
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+    def test_dunder_method_inverted_order(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(value2, lambda cell: value1 ^ cell, expected, type_if_none=DataTypes.Int64())
+
+    def test_dunder_method_inverted_order_wrapped_in_cell(
+        self,
+        value1: Any,
+        value2: int | None,
+        expected: int | None,
+    ) -> None:
+        assert_cell_operation_works(
+            value2,
+            lambda cell: ExprCell(pl.lit(value1), type=DataTypes.Unknown()) ^ cell,
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+    def test_named_method(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1, lambda cell: cell.bitwise_xor(value2), expected, type_if_none=DataTypes.Int64()
+        )
+
+    def test_named_method_wrapped_in_cell(self, value1: Any, value2: int | None, expected: int | None) -> None:
+        assert_cell_operation_works(
+            value1,
+            lambda cell: cell.bitwise_xor(ExprCell(pl.lit(value2), type=DataTypes.Unknown())),
+            expected,
+            type_if_none=DataTypes.Int64(),
+        )
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Boolean(), id="boolean"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+class TestShouldRaiseForNonIntegerTypeOnBitwiseXor:
+    def test_self(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(cell_type).bitwise_xor(1)
+
+    def test_other_cell(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()).bitwise_xor(cell_of_type(cell_type))
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+class TestShouldRaiseForNonIntegerTypeOnOperator:
+    def test_self(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(cell_type) ^ 1
+
+    def test_other_cell(self, cell_type: DataType) -> None:
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()) ^ cell_of_type(cell_type)
+
+
+class TestShouldSkipValidationForUnknownType:
+    def test_self(self) -> None:
+        _ = cell_of_unknown_type() ^ 1
+
+    def test_other_cell(self) -> None:
+        _ = cell_of_type(DataTypes.Int64()) ^ cell_of_unknown_type()
+
+    def test_other_literal_none(self) -> None:
+        _ = cell_of_type(DataTypes.Int64()) ^ None
+
+    def test_self_reflected(self) -> None:
+        _ = 1 ^ cell_of_unknown_type()
+
+
+@pytest.mark.parametrize(
+    ("given_type", "operation", "expected_type"),
+    [
+        pytest.param(DataTypes.Int64(), lambda cell: cell ^ 1, DataTypes.Int64(), id="__xor__"),
+        pytest.param(DataTypes.Int64(), lambda cell: 1 ^ cell, DataTypes.Int64(), id="__rxor__"),
+        pytest.param(DataTypes.Int64(), lambda cell: cell.bitwise_xor(1), DataTypes.Int64(), id="bitwise_xor"),
+        pytest.param(DataTypes.Int32(), lambda cell: cell ^ 1, DataTypes.Int32(), id="__xor___int32"),
+        pytest.param(DataTypes.UInt32(), lambda cell: cell ^ 1, DataTypes.UInt32(), id="__xor___uint32"),
+    ],
+)
+class TestShouldInferType:
+    def test_should_match_ground_truth(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        result = operation(cell_of_type(given_type))
+        assert_cell_has_type(result, expected_type)
+
+    def test_should_match_polars_type(
+        self, given_type: DataType, operation: Callable[[Cell], Cell], expected_type: DataType
+    ) -> None:
+        assert_cell_type_matches_polars(given_type, operation, expected_type)

--- a/tests/portabellas/containers/_cell/test_not.py
+++ b/tests/portabellas/containers/_cell/test_not.py
@@ -35,12 +35,23 @@ class TestShouldInvertValueOfCell:
     "cell_type",
     [
         pytest.param(DataTypes.String(), id="string"),
+        pytest.param(DataTypes.Float64(), id="float"),
+    ],
+)
+def test_should_raise_for_non_boolean_non_integer_type_on_operator(cell_type: DataType) -> None:
+    with pytest.raises(ColumnTypeError, match="Expected integer type"):
+        _ = ~cell_of_type(cell_type)
+
+
+@pytest.mark.parametrize(
+    "cell_type",
+    [
         pytest.param(DataTypes.Int64(), id="int"),
     ],
 )
-def test_should_raise_for_non_boolean_type(cell_type: DataType) -> None:
+def test_should_raise_for_non_boolean_type_on_named_method(cell_type: DataType) -> None:
     with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-        _ = ~cell_of_type(cell_type)
+        _ = cell_of_type(cell_type).not_()
 
 
 def test_should_skip_validation_for_unknown_type() -> None:

--- a/tests/portabellas/containers/_cell/test_or.py
+++ b/tests/portabellas/containers/_cell/test_or.py
@@ -75,31 +75,37 @@ class TestShouldComputeDisjunction:
     "cell_type",
     [
         pytest.param(DataTypes.String(), id="string"),
-        pytest.param(DataTypes.Int64(), id="int"),
+        pytest.param(DataTypes.Float64(), id="float"),
     ],
 )
-class TestShouldRaiseForNonBooleanType:
+class TestShouldRaiseForNonBooleanNonIntegerTypeOnOperator:
     def test_self(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
             _ = cell_of_type(cell_type) | True
 
     def test_other_cell(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = cell_of_type(DataTypes.Boolean()) | cell_of_type(cell_type)
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()) | cell_of_type(cell_type)
 
     def test_self_inverted_order(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
             _ = True | cell_of_type(cell_type)
 
 
-class TestShouldRaiseForNonBooleanLiteral:
-    def test_other_literal(self) -> None:
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Int64(), id="int"),
+    ],
+)
+class TestShouldRaiseForNonBooleanTypeOnNamedMethod:
+    def test_self(self, cell_type: DataType) -> None:
         with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = cell_of_type(DataTypes.Boolean()) | 1  # type: ignore[operator]
+            _ = cell_of_type(cell_type).or_(True)  # noqa: FBT003
 
-    def test_other_literal_inverted_order(self) -> None:
+    def test_other_cell(self, cell_type: DataType) -> None:
         with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = 1 | cell_of_type(DataTypes.Boolean())  # type: ignore[operator]
+            _ = cell_of_type(DataTypes.Boolean()).or_(cell_of_type(cell_type))
 
 
 class TestShouldSkipValidationForUnknownType:

--- a/tests/portabellas/containers/_cell/test_xor.py
+++ b/tests/portabellas/containers/_cell/test_xor.py
@@ -75,31 +75,37 @@ class TestShouldComputeExclusiveOr:
     "cell_type",
     [
         pytest.param(DataTypes.String(), id="string"),
-        pytest.param(DataTypes.Int64(), id="int"),
+        pytest.param(DataTypes.Float64(), id="float"),
     ],
 )
-class TestShouldRaiseForNonBooleanType:
+class TestShouldRaiseForNonBooleanNonIntegerTypeOnOperator:
     def test_self(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
             _ = cell_of_type(cell_type) ^ True
 
     def test_other_cell(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = cell_of_type(DataTypes.Boolean()) ^ cell_of_type(cell_type)
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
+            _ = cell_of_type(DataTypes.Int64()) ^ cell_of_type(cell_type)
 
     def test_self_inverted_order(self, cell_type: DataType) -> None:
-        with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
+        with pytest.raises(ColumnTypeError, match="Expected integer type"):
             _ = True ^ cell_of_type(cell_type)
 
 
-class TestShouldRaiseForNonBooleanLiteral:
-    def test_other_literal(self) -> None:
+@pytest.mark.parametrize(
+    "cell_type",
+    [
+        pytest.param(DataTypes.Int64(), id="int"),
+    ],
+)
+class TestShouldRaiseForNonBooleanTypeOnNamedMethod:
+    def test_self(self, cell_type: DataType) -> None:
         with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = cell_of_type(DataTypes.Boolean()) ^ 1  # type: ignore[operator]
+            _ = cell_of_type(cell_type).xor(True)  # noqa: FBT003
 
-    def test_other_literal_inverted_order(self) -> None:
+    def test_other_cell(self, cell_type: DataType) -> None:
         with pytest.raises(ColumnTypeError, match="Expected Boolean type"):
-            _ = 1 ^ cell_of_type(DataTypes.Boolean())  # type: ignore[operator]
+            _ = cell_of_type(DataTypes.Boolean()).xor(cell_of_type(cell_type))
 
 
 class TestShouldSkipValidationForUnknownType:


### PR DESCRIPTION
Closes #177

### Summary of Changes

- Relaxed the `&`, `|`, `^`, `~` operators on `Cell` to accept both Boolean and integer cells, following Python's convention where `&` on `bool` is logical and `&` on `int` is bitwise
- Added integer-only named methods with `bitwise_` prefix (`bitwise_and`, `bitwise_or`, `bitwise_xor`, `bitwise_invert`) to distinguish them from the existing Boolean-only named methods (`and_`, `or_`, `xor`, `not_`), which remain unchanged
- Added `CellTypeRequirements.INTEGER` validation requirement and `ConvertibleToBitwiseCell` type alias
- Shift operations (`<<`, `>>`) were omitted because Polars does not currently support bitwise shift on expressions
