### PR TITLE
feat(query): add SQL query support via Table.sql() and SQLContext

### DIFF
--- a/src/portabellas/__init__.py
+++ b/src/portabellas/__init__.py
@@ -1,5 +1,6 @@
 from .containers import Cell, Column, Row, Table
 from .exceptions import PortabellasError
+from .query import SQLContext
 from .typing import DataType, DataTypes, Schema
 
-__all__ = ["Cell", "Column", "DataType", "DataTypes", "PortabellasError", "Row", "Schema", "Table"]
+__all__ = ["Cell", "Column", "DataType", "DataTypes", "PortabellasError", "Row", "SQLContext", "Schema", "Table"]

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1759,7 +1759,6 @@ class Table:
         ------
         SQLQueryError
             If the query fails during query planning (e.g. syntax errors, missing column references).
-            Also raised if the query is an empty string, since Polars' error for that case is unhelpful.
 
         Examples
         --------

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1736,6 +1736,51 @@ class Table:
 
         return Table._from_polars_lazy_frame(result)
 
+    def sql(self, query: str) -> Table:
+        """
+        Execute an SQL query against this table and return the result as a new table.
+
+        The table is registered as `"self"` in the SQL context, so you can reference it in your query using
+        `FROM self`.
+
+        **Note:** The original table is not modified.
+
+        Parameters
+        ----------
+        query:
+            The SQL query to execute.
+
+        Returns
+        -------
+        result:
+            The table with the query results.
+
+        Raises
+        ------
+        SQLQueryError
+            If the query fails during query planning (e.g. syntax errors, missing column references).
+        ValueError
+            If the query is an empty string.
+
+        Examples
+        --------
+        >>> from portabellas import Table
+        >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> table.sql("SELECT * FROM self WHERE a > 1")
+        +-----+-----+
+        |   a |   b |
+        | --- | --- |
+        | i64 | i64 |
+        +===========+
+        |   2 |   5 |
+        |   3 |   6 |
+        +-----+-----+
+        """
+        from portabellas.query._sql_context import SQLContext  # circular import  # noqa: PLC0415
+
+        ctx = SQLContext(tables={"self": self})
+        return ctx.execute(query)
+
     # ------------------------------------------------------------------------------------------------------------------
     # Statistics
     # ------------------------------------------------------------------------------------------------------------------

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1759,8 +1759,7 @@ class Table:
         ------
         SQLQueryError
             If the query fails during query planning (e.g. syntax errors, missing column references).
-        ValueError
-            If the query is an empty string.
+            Also raised if the query is an empty string, since Polars' error for that case is unhelpful.
 
         Examples
         --------

--- a/src/portabellas/exceptions/__init__.py
+++ b/src/portabellas/exceptions/__init__.py
@@ -42,6 +42,10 @@ class SchemaError(PortabellasError, ValueError):
     """Raised when a schema does not match the expected schema."""
 
 
+class SQLQueryError(PortabellasError, ValueError):
+    """Raised when an SQL query fails during query planning."""
+
+
 class StructFieldNotFoundError(PortabellasError, KeyError):
     """Raised when a struct field is not found."""
 
@@ -57,6 +61,7 @@ __all__ = [
     "LengthMismatchError",
     "OutOfBoundsError",
     "PortabellasError",
+    "SQLQueryError",
     "SchemaError",
     "StructFieldNotFoundError",
 ]

--- a/src/portabellas/query/__init__.py
+++ b/src/portabellas/query/__init__.py
@@ -2,6 +2,7 @@ from ._datetime_operations import DatetimeOperations
 from ._duration_operations import DurationOperations
 from ._list_operations import ListOperations
 from ._math_operations import MathOperations
+from ._sql_context import SQLContext
 from ._string_operations import StringOperations
 from ._struct_operations import StructOperations
 
@@ -10,6 +11,7 @@ __all__ = [
     "DurationOperations",
     "ListOperations",
     "MathOperations",
+    "SQLContext",
     "StringOperations",
     "StructOperations",
 ]

--- a/src/portabellas/query/_sql_context.py
+++ b/src/portabellas/query/_sql_context.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import polars.exceptions as pl_exceptions
+
+from portabellas.exceptions import SQLQueryError
+
+if TYPE_CHECKING:
+    from portabellas import Table
+
+
+class SQLContext:
+    """
+    Execute SQL queries against one or more tables.
+
+    Parameters
+    ----------
+    tables:
+        A mapping from table names to `Table` objects. The table names are used as table identifiers in SQL queries.
+
+    Examples
+    --------
+    >>> from portabellas import Table
+    >>> from portabellas.query import SQLContext
+    >>> orders = Table({"order_id": [1, 2], "amount": [100, 200]})
+    >>> ctx = SQLContext(tables={"orders": orders})
+    >>> ctx.execute("SELECT * FROM orders WHERE amount > 100")
+    +----------+--------+
+    | order_id | amount |
+    | ---      | ---    |
+    | i64      | i64    |
+    +===================+
+    |        2 |    200 |
+    +----------+--------+
+    """
+
+    def __init__(self, tables: dict[str, Table]) -> None:
+        from portabellas.containers._table import Table  # circular import  # noqa: PLC0415
+
+        if not isinstance(tables, dict):
+            msg = f"Expected a dict, got {type(tables).__name__}"
+            raise TypeError(msg) from None
+
+        self._polars_context = pl.SQLContext()
+
+        for name, table in tables.items():
+            if not isinstance(table, Table):
+                msg = f"Expected a Table, got {type(table).__name__}"
+                raise TypeError(msg) from None
+
+            self._polars_context.register(name, table._lazy_frame)
+
+    def execute(self, query: str) -> Table:
+        """
+        Execute an SQL query against the registered tables and return the result as a new table.
+
+        Parameters
+        ----------
+        query:
+            The SQL query to execute.
+
+        Returns
+        -------
+        result:
+            The table with the query results.
+
+        Raises
+        ------
+        SQLQueryError
+            If the query fails during query planning (e.g. syntax errors, missing table or column references).
+        ValueError
+            If the query is an empty string.
+
+        Examples
+        --------
+        >>> from portabellas import Table
+        >>> from portabellas.query import SQLContext
+        >>> table = Table({"a": [1, 2, 3]})
+        >>> ctx = SQLContext(tables={"t": table})
+        >>> ctx.execute("SELECT * FROM t WHERE a > 1")
+        +-----+
+        |   a |
+        | --- |
+        | i64 |
+        +=====+
+        |   2 |
+        |   3 |
+        +-----+
+        """
+        from portabellas.containers._table import Table  # circular import  # noqa: PLC0415
+
+        if not query:
+            msg = "The query must not be empty."
+            raise ValueError(msg) from None
+
+        try:
+            lazy_frame = self._polars_context.execute(query)
+        except pl_exceptions.PolarsError as e:
+            raise SQLQueryError(str(e)) from None
+
+        return Table._from_polars_lazy_frame(lazy_frame)

--- a/src/portabellas/query/_sql_context.py
+++ b/src/portabellas/query/_sql_context.py
@@ -37,19 +37,9 @@ class SQLContext:
     """
 
     def __init__(self, tables: dict[str, Table]) -> None:
-        from portabellas.containers._table import Table  # circular import  # noqa: PLC0415
-
-        if not isinstance(tables, dict):
-            msg = f"Expected a dict, got {type(tables).__name__}"
-            raise TypeError(msg) from None
-
         self._polars_context = pl.SQLContext()
 
         for name, table in tables.items():
-            if not isinstance(table, Table):
-                msg = f"Expected a Table, got {type(table).__name__}"
-                raise TypeError(msg) from None
-
             self._polars_context.register(name, table._lazy_frame)
 
     def execute(self, query: str) -> Table:
@@ -70,8 +60,7 @@ class SQLContext:
         ------
         SQLQueryError
             If the query fails during query planning (e.g. syntax errors, missing table or column references).
-        ValueError
-            If the query is an empty string.
+            Also raised if the query is an empty string, since Polars' error for that case is unhelpful.
 
         Examples
         --------
@@ -92,8 +81,9 @@ class SQLContext:
         from portabellas.containers._table import Table  # circular import  # noqa: PLC0415
 
         if not query:
+            # Polars' error for an empty query is unhelpful, so we validate explicitly
             msg = "The query must not be empty."
-            raise ValueError(msg) from None
+            raise SQLQueryError(msg) from None
 
         try:
             lazy_frame = self._polars_context.execute(query)

--- a/src/portabellas/query/_sql_context.py
+++ b/src/portabellas/query/_sql_context.py
@@ -24,16 +24,22 @@ class SQLContext:
     --------
     >>> from portabellas import Table
     >>> from portabellas.query import SQLContext
-    >>> orders = Table({"order_id": [1, 2], "amount": [100, 200]})
-    >>> ctx = SQLContext(tables={"orders": orders})
-    >>> ctx.execute("SELECT * FROM orders WHERE amount > 100")
-    +----------+--------+
-    | order_id | amount |
-    | ---      | ---    |
-    | i64      | i64    |
-    +===================+
-    |        2 |    200 |
-    +----------+--------+
+    >>> orders = Table({"order_id": [1, 2], "customer_id": [10, 20]})
+    >>> customers = Table({"customer_id": [10, 20], "name": ["Alice", "Bob"]})
+    >>> ctx = SQLContext(tables={"orders": orders, "customers": customers})
+    >>> ctx.execute(
+    ...     "SELECT o.order_id, c.name "
+    ...     "FROM orders AS o JOIN customers AS c ON o.customer_id = c.customer_id "
+    ...     "ORDER BY o.order_id"
+    ... )
+    +----------+-------+
+    | order_id | name  |
+    |      --- | ---   |
+    |      i64 | str   |
+    +==================+
+    |        1 | Alice |
+    |        2 | Bob   |
+    +----------+-------+
     """
 
     def __init__(self, tables: dict[str, Table]) -> None:

--- a/src/portabellas/query/_sql_context.py
+++ b/src/portabellas/query/_sql_context.py
@@ -66,7 +66,6 @@ class SQLContext:
         ------
         SQLQueryError
             If the query fails during query planning (e.g. syntax errors, missing table or column references).
-            Also raised if the query is an empty string, since Polars' error for that case is unhelpful.
 
         Examples
         --------
@@ -86,8 +85,8 @@ class SQLContext:
         """
         from portabellas.containers._table import Table  # circular import  # noqa: PLC0415
 
+        # Polars' error for an empty query is unhelpful, so we validate explicitly
         if not query:
-            # Polars' error for an empty query is unhelpful, so we validate explicitly
             msg = "The query must not be empty."
             raise SQLQueryError(msg) from None
 

--- a/tests/portabellas/containers/_table/test_sql.py
+++ b/tests/portabellas/containers/_table/test_sql.py
@@ -97,5 +97,5 @@ def test_should_raise_on_query_planning_error(query: str, error_type: type) -> N
 
 def test_should_raise_on_empty_query() -> None:
     table = Table({"a": [1, 2, 3]})
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(SQLQueryError, match="empty"):
         table.sql("")

--- a/tests/portabellas/containers/_table/test_sql.py
+++ b/tests/portabellas/containers/_table/test_sql.py
@@ -70,31 +70,27 @@ class TestSQLMethod:
 
 
 @pytest.mark.parametrize(
-    ("query", "error_type"),
+    "query",
     [
         pytest.param(
             "",
-            SQLQueryError,
             id="empty query",
         ),
         pytest.param(
             "SELECT FROM",
-            SQLQueryError,
             id="syntax error",
         ),
         pytest.param(
             "SELECT * FROM nonexistent",
-            SQLQueryError,
             id="missing table",
         ),
         pytest.param(
             "SELECT nonexistent FROM self",
-            SQLQueryError,
             id="missing column",
         ),
     ],
 )
-def test_should_raise_on_query_planning_error(query: str, error_type: type) -> None:
+def test_should_raise_on_query_planning_error(query: str) -> None:
     table = Table({"a": [1, 2, 3]})
-    with pytest.raises(error_type):
+    with pytest.raises(SQLQueryError):
         table.sql(query)

--- a/tests/portabellas/containers/_table/test_sql.py
+++ b/tests/portabellas/containers/_table/test_sql.py
@@ -73,6 +73,11 @@ class TestSQLMethod:
     ("query", "error_type"),
     [
         pytest.param(
+            "",
+            SQLQueryError,
+            id="empty query",
+        ),
+        pytest.param(
             "SELECT FROM",
             SQLQueryError,
             id="syntax error",
@@ -93,9 +98,3 @@ def test_should_raise_on_query_planning_error(query: str, error_type: type) -> N
     table = Table({"a": [1, 2, 3]})
     with pytest.raises(error_type):
         table.sql(query)
-
-
-def test_should_raise_on_empty_query() -> None:
-    table = Table({"a": [1, 2, 3]})
-    with pytest.raises(SQLQueryError, match="empty"):
-        table.sql("")

--- a/tests/portabellas/containers/_table/test_sql.py
+++ b/tests/portabellas/containers/_table/test_sql.py
@@ -1,0 +1,101 @@
+from collections.abc import Callable
+
+import pytest
+
+from portabellas import Table
+from portabellas.exceptions import SQLQueryError
+from tests.helpers import assert_tables_are_equal
+
+
+@pytest.mark.parametrize(
+    ("table_factory", "query", "expected"),
+    [
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            "SELECT * FROM self",
+            Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            id="select all",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            "SELECT a FROM self",
+            Table({"a": [1, 2, 3]}),
+            id="select one column",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            "SELECT * FROM self WHERE a > 1",
+            Table({"a": [2, 3], "b": [5, 6]}),
+            id="filter with WHERE",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3]}),
+            "SELECT a + 1 AS a FROM self",
+            Table({"a": [2, 3, 4]}),
+            id="computed column",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3]}),
+            "SELECT a AS a FROM self ORDER BY a DESC",
+            Table({"a": [3, 2, 1]}),
+            id="order by",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 1, 2]}),
+            "SELECT DISTINCT a AS a FROM self ORDER BY a",
+            Table({"a": [1, 2]}),
+            id="select distinct",
+        ),
+    ],
+)
+class TestSQLMethod:
+    def test_should_execute_sql_query(
+        self,
+        table_factory: Callable[[], Table],
+        query: str,
+        expected: Table,
+    ) -> None:
+        actual = table_factory().sql(query)
+        assert_tables_are_equal(actual, expected)
+
+    def test_should_not_mutate_receiver(
+        self,
+        table_factory: Callable[[], Table],
+        query: str,
+        expected: Table,  # noqa: ARG002
+    ) -> None:
+        original = table_factory()
+        original.sql(query)
+        assert_tables_are_equal(original, table_factory())
+
+
+@pytest.mark.parametrize(
+    ("query", "error_type"),
+    [
+        pytest.param(
+            "SELECT FROM",
+            SQLQueryError,
+            id="syntax error",
+        ),
+        pytest.param(
+            "SELECT * FROM nonexistent",
+            SQLQueryError,
+            id="missing table",
+        ),
+        pytest.param(
+            "SELECT nonexistent FROM self",
+            SQLQueryError,
+            id="missing column",
+        ),
+    ],
+)
+def test_should_raise_on_query_planning_error(query: str, error_type: type) -> None:
+    table = Table({"a": [1, 2, 3]})
+    with pytest.raises(error_type):
+        table.sql(query)
+
+
+def test_should_raise_on_empty_query() -> None:
+    table = Table({"a": [1, 2, 3]})
+    with pytest.raises(ValueError, match="empty"):
+        table.sql("")

--- a/tests/portabellas/query/test_sql_context.py
+++ b/tests/portabellas/query/test_sql_context.py
@@ -1,0 +1,90 @@
+import pytest
+
+from portabellas import Table
+from portabellas.exceptions import SQLQueryError
+from portabellas.query import SQLContext
+from tests.helpers import assert_tables_are_equal
+
+
+@pytest.mark.parametrize(
+    ("tables", "query", "expected"),
+    [
+        pytest.param(
+            {"t1": Table({"a": [1, 2, 3]})},
+            "SELECT * FROM t1",
+            Table({"a": [1, 2, 3]}),
+            id="single table select all",
+        ),
+        pytest.param(
+            {"t1": Table({"a": [1, 2, 3]})},
+            "SELECT a FROM t1 WHERE a > 1",
+            Table({"a": [2, 3]}),
+            id="single table filter",
+        ),
+        pytest.param(
+            {
+                "orders": Table({"order_id": [1, 2, 3], "customer_id": [10, 20, 30], "amount": [100, 200, 300]}),
+                "customers": Table({"customer_id": [10, 20, 40], "name": ["Alice", "Bob", "Charlie"]}),
+            },
+            "SELECT o.order_id, c.name "
+            "FROM orders AS o JOIN customers AS c ON o.customer_id = c.customer_id "
+            "ORDER BY o.order_id",
+            Table({"order_id": [1, 2], "name": ["Alice", "Bob"]}),
+            id="join two tables",
+        ),
+    ],
+)
+class TestSQLContextExecute:
+    def test_should_execute_sql_query(
+        self,
+        tables: dict[str, Table],
+        query: str,
+        expected: Table,
+    ) -> None:
+        ctx = SQLContext(tables=tables)
+        actual = ctx.execute(query)
+        assert_tables_are_equal(actual, expected)
+
+    def test_should_not_mutate_input_tables(
+        self,
+        tables: dict[str, Table],
+        query: str,
+        expected: Table,  # noqa: ARG002
+    ) -> None:
+        originals = {name: Table(table.to_dict()) for name, table in tables.items()}
+        ctx = SQLContext(tables=tables)
+        ctx.execute(query)
+        for name, original in originals.items():
+            assert_tables_are_equal(tables[name], original)
+
+
+@pytest.mark.parametrize(
+    ("query", "error_type"),
+    [
+        pytest.param(
+            "SELECT FROM",
+            SQLQueryError,
+            id="syntax error",
+        ),
+        pytest.param(
+            "SELECT * FROM nonexistent",
+            SQLQueryError,
+            id="missing table",
+        ),
+        pytest.param(
+            "SELECT nonexistent FROM t1",
+            SQLQueryError,
+            id="missing column",
+        ),
+    ],
+)
+def test_should_raise_on_query_planning_error(query: str, error_type: type) -> None:
+    ctx = SQLContext(tables={"t1": Table({"a": [1, 2, 3]})})
+    with pytest.raises(error_type):
+        ctx.execute(query)
+
+
+def test_should_raise_on_empty_query() -> None:
+    ctx = SQLContext(tables={"t1": Table({"a": [1, 2, 3]})})
+    with pytest.raises(ValueError, match="empty"):
+        ctx.execute("")

--- a/tests/portabellas/query/test_sql_context.py
+++ b/tests/portabellas/query/test_sql_context.py
@@ -62,6 +62,11 @@ class TestSQLContextExecute:
     ("query", "error_type"),
     [
         pytest.param(
+            "",
+            SQLQueryError,
+            id="empty query",
+        ),
+        pytest.param(
             "SELECT FROM",
             SQLQueryError,
             id="syntax error",
@@ -82,9 +87,3 @@ def test_should_raise_on_query_planning_error(query: str, error_type: type) -> N
     ctx = SQLContext(tables={"t1": Table({"a": [1, 2, 3]})})
     with pytest.raises(error_type):
         ctx.execute(query)
-
-
-def test_should_raise_on_empty_query() -> None:
-    ctx = SQLContext(tables={"t1": Table({"a": [1, 2, 3]})})
-    with pytest.raises(SQLQueryError, match="empty"):
-        ctx.execute("")

--- a/tests/portabellas/query/test_sql_context.py
+++ b/tests/portabellas/query/test_sql_context.py
@@ -59,31 +59,27 @@ class TestSQLContextExecute:
 
 
 @pytest.mark.parametrize(
-    ("query", "error_type"),
+    "query",
     [
         pytest.param(
             "",
-            SQLQueryError,
             id="empty query",
         ),
         pytest.param(
             "SELECT FROM",
-            SQLQueryError,
             id="syntax error",
         ),
         pytest.param(
             "SELECT * FROM nonexistent",
-            SQLQueryError,
             id="missing table",
         ),
         pytest.param(
             "SELECT nonexistent FROM t1",
-            SQLQueryError,
             id="missing column",
         ),
     ],
 )
-def test_should_raise_on_query_planning_error(query: str, error_type: type) -> None:
+def test_should_raise_on_query_planning_error(query: str) -> None:
     ctx = SQLContext(tables={"t1": Table({"a": [1, 2, 3]})})
-    with pytest.raises(error_type):
+    with pytest.raises(SQLQueryError):
         ctx.execute(query)

--- a/tests/portabellas/query/test_sql_context.py
+++ b/tests/portabellas/query/test_sql_context.py
@@ -86,5 +86,5 @@ def test_should_raise_on_query_planning_error(query: str, error_type: type) -> N
 
 def test_should_raise_on_empty_query() -> None:
     ctx = SQLContext(tables={"t1": Table({"a": [1, 2, 3]})})
-    with pytest.raises(ValueError, match="empty"):
+    with pytest.raises(SQLQueryError, match="empty"):
         ctx.execute("")


### PR DESCRIPTION
Closes #170

### Summary of Changes

- Add `Table.sql(query)` convenience method for single-table SQL queries, where the table is referenced as `self` in the query (since `table` is a SQL reserved word)
- Add `SQLContext` class for multi-table SQL queries, accepting a `dict[str, Table]` mapping table names to tables, with an `execute(query)` method
- Add `SQLQueryError` exception wrapping Polars SQL query planning errors (syntax errors, missing table/column references); lazy computation errors during `.collect()` still surface as `LazyComputationError`
- Re-export `SQLContext` from `portabellas.query` and `portabellas` top-level
