### PR TITLE
feat(containers): add public Polars conversion methods

### DIFF
--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -1142,6 +1142,24 @@ class Column[T_co](Sequence[T_co]):
     # Export
     # ------------------------------------------------------------------------------------------------------------------
 
+    def to_list(self) -> list[T_co]:
+        """
+        Return the values of the column in a list.
+
+        Returns
+        -------
+        values:
+            The values of the column.
+
+        Examples
+        --------
+        >>> from portabellas import Column
+        >>> column = Column("a", [1, 2, 3])
+        >>> column.to_list()
+        [1, 2, 3]
+        """
+        return self._series.to_list()
+
     def to_polars(self) -> pl.Series:
         """
         Return the internal Polars Series.
@@ -1166,24 +1184,6 @@ class Column[T_co](Sequence[T_co]):
         ]
         """
         return self._series
-
-    def to_list(self) -> list[T_co]:
-        """
-        Return the values of the column in a list.
-
-        Returns
-        -------
-        values:
-            The values of the column.
-
-        Examples
-        --------
-        >>> from portabellas import Column
-        >>> column = Column("a", [1, 2, 3])
-        >>> column.to_list()
-        [1, 2, 3]
-        """
-        return self._series.to_list()
 
     def to_table(self) -> Table:
         """

--- a/src/portabellas/containers/_column.py
+++ b/src/portabellas/containers/_column.py
@@ -71,6 +71,38 @@ class Column[T_co](Sequence[T_co]):
     # ------------------------------------------------------------------------------------------------------------------
 
     @staticmethod
+    def from_polars(data: pl.Series) -> Column:
+        """
+        Create a column from a Polars Series.
+
+        Parameters
+        ----------
+        data:
+            The Polars Series.
+
+        Returns
+        -------
+        column:
+            The created column.
+
+        Examples
+        --------
+        >>> import polars as pl
+        >>> from portabellas import Column
+        >>> Column.from_polars(pl.Series("a", [1, 2, 3]))
+        +-----+
+        |   a |
+        | --- |
+        | i64 |
+        +=====+
+        |   1 |
+        |   2 |
+        |   3 |
+        +-----+
+        """
+        return Column._from_polars_series(data)
+
+    @staticmethod
     def _from_polars_series(data: pl.Series) -> Column:
         result = object.__new__(Column)
         result._name = data.name
@@ -1109,6 +1141,31 @@ class Column[T_co](Sequence[T_co]):
     # ------------------------------------------------------------------------------------------------------------------
     # Export
     # ------------------------------------------------------------------------------------------------------------------
+
+    def to_polars(self) -> pl.Series:
+        """
+        Return the internal Polars Series.
+
+        Returns
+        -------
+        series:
+            The Polars Series.
+
+        Examples
+        --------
+        >>> import polars as pl
+        >>> from portabellas import Column
+        >>> column = Column("a", [1, 2, 3])
+        >>> column.to_polars()
+        shape: (3,)
+        Series: 'a' [i64]
+        [
+            1
+            2
+            3
+        ]
+        """
+        return self._series
 
     def to_list(self) -> list[T_co]:
         """

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -175,6 +175,50 @@ class Table:
         return Table(data)
 
     @staticmethod
+    def from_polars(data: pl.LazyFrame | pl.DataFrame) -> Table:
+        """
+        Create a table from a Polars LazyFrame or DataFrame.
+
+        Parameters
+        ----------
+        data:
+            The Polars LazyFrame or DataFrame.
+
+        Returns
+        -------
+        table:
+            The created table.
+
+        Examples
+        --------
+        >>> import polars as pl
+        >>> from portabellas import Table
+        >>> Table.from_polars(pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+        +-----+-----+
+        |   a |   b |
+        | --- | --- |
+        | i64 | i64 |
+        +===========+
+        |   1 |   4 |
+        |   2 |   5 |
+        |   3 |   6 |
+        +-----+-----+
+        >>> Table.from_polars(pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+        +-----+-----+
+        |   a |   b |
+        | --- | --- |
+        | i64 | i64 |
+        +===========+
+        |   1 |   4 |
+        |   2 |   5 |
+        |   3 |   6 |
+        +-----+-----+
+        """
+        if isinstance(data, pl.DataFrame):
+            return Table._from_polars_data_frame(data)
+        return Table._from_polars_lazy_frame(data)
+
+    @staticmethod
     def _from_polars_data_frame(data: pl.DataFrame) -> Table:
         result = object.__new__(Table)
         result.__data_frame_cache = data
@@ -1859,6 +1903,34 @@ class Table:
     # ------------------------------------------------------------------------------------------------------------------
     # Export
     # ------------------------------------------------------------------------------------------------------------------
+
+    def to_polars(self) -> pl.LazyFrame:
+        """
+        Return the internal Polars LazyFrame.
+
+        Returns
+        -------
+        lazy_frame:
+            The Polars LazyFrame.
+
+        Examples
+        --------
+        >>> import polars as pl
+        >>> from portabellas import Table
+        >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> table.to_polars().collect()
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 4   │
+        │ 2   ┆ 5   │
+        │ 3   ┆ 6   │
+        └─────┴─────┘
+        """
+        return self._lazy_frame
 
     def to_columns(self) -> list[Column]:
         """

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1904,34 +1904,6 @@ class Table:
     # Export
     # ------------------------------------------------------------------------------------------------------------------
 
-    def to_polars(self) -> pl.LazyFrame:
-        """
-        Return the internal Polars LazyFrame.
-
-        Returns
-        -------
-        lazy_frame:
-            The Polars LazyFrame.
-
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from portabellas import Table
-        >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
-        >>> table.to_polars().collect()
-        shape: (3, 2)
-        ┌─────┬─────┐
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 1   ┆ 4   │
-        │ 2   ┆ 5   │
-        │ 3   ┆ 6   │
-        └─────┴─────┘
-        """
-        return self._lazy_frame
-
     def to_columns(self) -> list[Column]:
         """
         Return the data of the table as a list of columns.
@@ -1968,6 +1940,34 @@ class Table:
         {'a': [1, 2, 3], 'b': [4, 5, 6]}
         """
         return self._data_frame.to_dict(as_series=False)
+
+    def to_polars(self) -> pl.LazyFrame:
+        """
+        Return the internal Polars LazyFrame.
+
+        Returns
+        -------
+        lazy_frame:
+            The Polars LazyFrame.
+
+        Examples
+        --------
+        >>> import polars as pl
+        >>> from portabellas import Table
+        >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> table.to_polars().collect()
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 4   │
+        │ 2   ┆ 5   │
+        │ 3   ┆ 6   │
+        └─────┴─────┘
+        """
+        return self._lazy_frame
 
     # ------------------------------------------------------------------------------------------------------------------
     # IPython integration

--- a/tests/portabellas/containers/_column/test_from_polars.py
+++ b/tests/portabellas/containers/_column/test_from_polars.py
@@ -1,0 +1,28 @@
+import polars as pl
+import pytest
+
+from portabellas import Column
+from portabellas.typing import DataTypes
+
+
+@pytest.mark.parametrize(
+    ("series", "expected_name", "expected_data"),
+    [
+        pytest.param(pl.Series("col1", []), "col1", [], id="empty"),
+        pytest.param(pl.Series("col1", [1, 2]), "col1", [1, 2], id="non-empty"),
+        pytest.param(pl.Series("col1", ["a", "b"]), "col1", ["a", "b"], id="strings"),
+    ],
+)
+def test_should_create_column_from_series(
+    series: pl.Series,
+    expected_name: str,
+    expected_data: list,
+) -> None:
+    result = Column.from_polars(series)
+    assert result.name == expected_name
+    assert list(result) == expected_data
+
+
+def test_should_have_correct_type() -> None:
+    series = pl.Series("col1", [1])
+    assert Column.from_polars(series).type == DataTypes.Int64()

--- a/tests/portabellas/containers/_column/test_from_polars.py
+++ b/tests/portabellas/containers/_column/test_from_polars.py
@@ -2,27 +2,16 @@ import polars as pl
 import pytest
 
 from portabellas import Column
-from portabellas.typing import DataTypes
 
 
 @pytest.mark.parametrize(
-    ("series", "expected_name", "expected_data"),
+    ("series", "expected"),
     [
-        pytest.param(pl.Series("col1", []), "col1", [], id="empty"),
-        pytest.param(pl.Series("col1", [1, 2]), "col1", [1, 2], id="non-empty"),
-        pytest.param(pl.Series("col1", ["a", "b"]), "col1", ["a", "b"], id="strings"),
+        pytest.param(pl.Series("col1", []), Column("col1", []), id="empty"),
+        pytest.param(pl.Series("col1", [1, 2]), Column("col1", [1, 2]), id="ints"),
+        pytest.param(pl.Series("col1", ["a", "b"]), Column("col1", ["a", "b"]), id="strings"),
     ],
 )
-def test_should_create_column_from_series(
-    series: pl.Series,
-    expected_name: str,
-    expected_data: list,
-) -> None:
-    result = Column.from_polars(series)
-    assert result.name == expected_name
-    assert list(result) == expected_data
-
-
-def test_should_have_correct_type() -> None:
-    series = pl.Series("col1", [1])
-    assert Column.from_polars(series).type == DataTypes.Int64()
+def test_should_create_column_from_series(series: pl.Series, expected: Column) -> None:
+    actual = Column.from_polars(series)
+    assert actual == expected

--- a/tests/portabellas/containers/_column/test_to_polars.py
+++ b/tests/portabellas/containers/_column/test_to_polars.py
@@ -1,0 +1,22 @@
+import polars as pl
+
+from portabellas import Column
+
+
+def test_should_return_series() -> None:
+    column = Column("col1", [1, 2, 3])
+    result = column.to_polars()
+    assert isinstance(result, pl.Series)
+
+
+def test_should_preserve_name() -> None:
+    column = Column("col1", [1, 2, 3])
+    result = column.to_polars()
+    assert result.name == "col1"
+
+
+def test_should_preserve_data() -> None:
+    column = Column("col1", [1, 2, 3])
+    result = column.to_polars()
+    expected = pl.Series("col1", [1, 2, 3])
+    assert result.equals(expected)

--- a/tests/portabellas/containers/_table/test_from_polars.py
+++ b/tests/portabellas/containers/_table/test_from_polars.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+import polars as pl
+import pytest
+
+from portabellas import Table
+from tests.helpers import assert_tables_are_equal
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"col1": []}, id="no rows"),
+        pytest.param({"col1": [1, 2], "col2": [3, 4]}, id="non-empty"),
+    ],
+)
+def test_should_create_table_from_data_frame(data: dict[str, list[Any]]) -> None:
+    actual = Table.from_polars(pl.DataFrame(data))
+    expected = Table(data)
+    assert_tables_are_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"col1": []}, id="no rows"),
+        pytest.param({"col1": [1, 2], "col2": [3, 4]}, id="non-empty"),
+    ],
+)
+def test_should_create_table_from_lazy_frame(data: dict[str, list[Any]]) -> None:
+    actual = Table.from_polars(pl.LazyFrame(data))
+    expected = Table(data)
+    assert_tables_are_equal(actual, expected)

--- a/tests/portabellas/containers/_table/test_from_polars.py
+++ b/tests/portabellas/containers/_table/test_from_polars.py
@@ -15,21 +15,13 @@ from tests.helpers import assert_tables_are_equal
         pytest.param({"col1": [1, 2], "col2": [3, 4]}, id="non-empty"),
     ],
 )
-def test_should_create_table_from_data_frame(data: dict[str, list[Any]]) -> None:
-    actual = Table.from_polars(pl.DataFrame(data))
-    expected = Table(data)
-    assert_tables_are_equal(actual, expected)
+class TestFromPolars:
+    def test_should_create_table_from_data_frame(self, data: dict[str, list[Any]]) -> None:
+        actual = Table.from_polars(pl.DataFrame(data))
+        expected = Table(data)
+        assert_tables_are_equal(actual, expected)
 
-
-@pytest.mark.parametrize(
-    "data",
-    [
-        pytest.param({}, id="empty"),
-        pytest.param({"col1": []}, id="no rows"),
-        pytest.param({"col1": [1, 2], "col2": [3, 4]}, id="non-empty"),
-    ],
-)
-def test_should_create_table_from_lazy_frame(data: dict[str, list[Any]]) -> None:
-    actual = Table.from_polars(pl.LazyFrame(data))
-    expected = Table(data)
-    assert_tables_are_equal(actual, expected)
+    def test_should_create_table_from_lazy_frame(self, data: dict[str, list[Any]]) -> None:
+        actual = Table.from_polars(pl.LazyFrame(data))
+        expected = Table(data)
+        assert_tables_are_equal(actual, expected)

--- a/tests/portabellas/containers/_table/test_to_polars.py
+++ b/tests/portabellas/containers/_table/test_to_polars.py
@@ -1,21 +1,21 @@
+from typing import Any
+
 import polars as pl
+import pytest
 
 from portabellas import Table
 
 
-def test_should_return_lazy_frame() -> None:
-    table = Table({"col1": [1, 2], "col2": [3, 4]})
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"col1": []}, id="no rows"),
+        pytest.param({"col1": [1, 2], "col2": [3, 4]}, id="non-empty"),
+    ],
+)
+def test_should_return_lazy_frame_with_preserved_data(data: dict[str, list[Any]]) -> None:
+    table = Table(data)
     result = table.to_polars()
     assert isinstance(result, pl.LazyFrame)
-
-
-def test_should_preserve_data() -> None:
-    table = Table({"col1": [1, 2], "col2": [3, 4]})
-    result = table.to_polars().collect()
-    expected = pl.DataFrame({"col1": [1, 2], "col2": [3, 4]})
-    assert result.equals(expected)
-
-
-def test_should_return_same_lazy_frame_as_internal() -> None:
-    table = Table({"col1": [1, 2]})
-    assert table.to_polars() is table._lazy_frame
+    assert result.collect().equals(pl.DataFrame(data))

--- a/tests/portabellas/containers/_table/test_to_polars.py
+++ b/tests/portabellas/containers/_table/test_to_polars.py
@@ -1,0 +1,21 @@
+import polars as pl
+
+from portabellas import Table
+
+
+def test_should_return_lazy_frame() -> None:
+    table = Table({"col1": [1, 2], "col2": [3, 4]})
+    result = table.to_polars()
+    assert isinstance(result, pl.LazyFrame)
+
+
+def test_should_preserve_data() -> None:
+    table = Table({"col1": [1, 2], "col2": [3, 4]})
+    result = table.to_polars().collect()
+    expected = pl.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    assert result.equals(expected)
+
+
+def test_should_return_same_lazy_frame_as_internal() -> None:
+    table = Table({"col1": [1, 2]})
+    assert table.to_polars() is table._lazy_frame


### PR DESCRIPTION
Closes #197

### Summary of Changes

- Add `Table.from_polars(data: pl.LazyFrame | pl.DataFrame) -> Table` and `Table.to_polars() -> pl.LazyFrame` to allow power users to convert between portabellas and Polars without accessing private attributes.
- Add `Column.from_polars(data: pl.Series) -> Column` and `Column.to_polars() -> pl.Series` for the same purpose at the column level.
