### PR TITLE
feat(containers): add Table.select_computed_columns

### DIFF
--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1092,9 +1092,6 @@ class Table:
         |   9 |  18 |
         +-----+-----+
         """
-        if len(mappers) == 0:
-            return Table._from_polars_lazy_frame(self._lazy_frame.select([]))
-
         if self.column_count == 0:
             return Table({name: [] for name in mappers})
 

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1054,12 +1054,11 @@ class Table:
         """
         Compute new columns and return a table containing only those columns.
 
-        Unlike :meth:`add_computed_columns`, which keeps the original columns, this method
-        drops all original columns and returns only the mapper-defined columns.
+        Unlike `add_computed_columns`, which keeps the original columns, this method drops all original columns and
+        returns only the mapper-defined columns.
 
-        Each mapper receives the same row and is evaluated independently — a mapper cannot
-        reference columns added by another mapper in the same call. Chain
-        :meth:`add_computed_column` or :meth:`add_computed_columns` calls if later mappers
+        Each mapper receives the same row and is evaluated independently — a mapper cannot reference columns added by
+        another mapper in the same call. Chain `add_computed_column` or `add_computed_columns` calls if later mappers
         depend on earlier results.
 
         **Note:** The original table is not modified.
@@ -1068,7 +1067,7 @@ class Table:
         ----------
         mappers:
             A dictionary mapping column names to mapper callbacks. Each callback
-            receives a :class:`Row` and returns a :class:`Cell`. Column names may overlap
+            receives a `Row` and returns a `Cell`. Column names may overlap
             with existing column names — the computed columns replace the originals.
 
         Returns

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -1047,6 +1047,69 @@ class Table:
             self._lazy_frame.select(selector),
         )
 
+    def select_computed_columns(
+        self,
+        mappers: dict[str, Callable[[Row], Cell]],
+    ) -> Table:
+        """
+        Compute new columns and return a table containing only those columns.
+
+        Unlike :meth:`add_computed_columns`, which keeps the original columns, this method
+        drops all original columns and returns only the mapper-defined columns.
+
+        Each mapper receives the same row and is evaluated independently — a mapper cannot
+        reference columns added by another mapper in the same call. Chain
+        :meth:`add_computed_column` or :meth:`add_computed_columns` calls if later mappers
+        depend on earlier results.
+
+        **Note:** The original table is not modified.
+
+        Parameters
+        ----------
+        mappers:
+            A dictionary mapping column names to mapper callbacks. Each callback
+            receives a :class:`Row` and returns a :class:`Cell`. Column names may overlap
+            with existing column names — the computed columns replace the originals.
+
+        Returns
+        -------
+        new_table:
+            A table containing only the computed columns. Original columns are dropped.
+
+        Examples
+        --------
+        >>> from portabellas import Table
+        >>> table = Table({"a": [1, 2, 3], "b": [4, 5, 6]})
+        >>> table.select_computed_columns(
+        ...     {"c": lambda row: row["a"] + row["b"], "d": lambda row: row["a"] * row["b"]},
+        ... )
+        +-----+-----+
+        |   c |   d |
+        | --- | --- |
+        | i64 | i64 |
+        +===========+
+        |   5 |   4 |
+        |   7 |  10 |
+        |   9 |  18 |
+        +-----+-----+
+        """
+        if len(mappers) == 0:
+            return Table._from_polars_lazy_frame(self._lazy_frame.select([]))
+
+        if self.column_count == 0:
+            return Table({name: [] for name in mappers})
+
+        expr_row = ExprRow(self)
+        result_cells = {name: mapper(expr_row) for name, mapper in mappers.items()}
+        expressions = [cell._polars_expression.alias(name) for name, cell in result_cells.items()]
+
+        result_schema = Schema({name: cell._type for name, cell in result_cells.items()})
+
+        return self._from_polars_lazy_frame(
+            self._lazy_frame.with_columns(expressions).select(list(mappers.keys())),
+            schema=result_schema,
+        )
+
     def transform_columns(
         self,
         selector: str | list[str],

--- a/src/portabellas/containers/_table.py
+++ b/src/portabellas/containers/_table.py
@@ -551,17 +551,15 @@ class Table:
         Add multiple computed columns to the table and return the result as a new table.
 
         Each mapper receives the same row and is evaluated independently — a mapper cannot
-        reference columns added by another mapper in the same call. Chain
-        :meth:`add_computed_column` or :meth:`add_computed_columns` calls if later mappers
-        depend on earlier results.
+        reference columns added by another mapper in the same call. Chain `add_computed_column` or
+        `add_computed_columns` calls if later mappers depend on earlier results.
 
         **Note:** The original table is not modified.
 
         Parameters
         ----------
         mappers:
-            A dictionary mapping new column names to mapper callbacks. Each callback
-            receives a :class:`Row` and returns a :class:`Cell`.
+            A dictionary mapping new column names to mapper callbacks.
 
         Returns
         -------

--- a/tests/portabellas/containers/_table/test_select_computed_columns.py
+++ b/tests/portabellas/containers/_table/test_select_computed_columns.py
@@ -1,0 +1,103 @@
+from collections.abc import Callable
+
+import pytest
+
+from portabellas import Table
+from portabellas.containers import Cell, Row
+from portabellas.containers._cell._expr_cell import ExprCell
+from portabellas.typing import DataTypes
+from tests.helpers import assert_tables_are_equal
+
+
+@pytest.mark.parametrize(
+    ("table_factory", "mappers", "expected"),
+    [
+        pytest.param(
+            lambda: Table({"a": [1]}),
+            {},
+            Table({}),
+            id="empty mappers dict",
+        ),
+        pytest.param(
+            lambda: Table({}),
+            {"col1": lambda _: Cell.constant(None)},
+            Table({"col1": []}),
+            id="empty table, single mapper",
+        ),
+        pytest.param(
+            lambda: Table({"col1": []}),
+            {"col2": lambda _: Cell.constant(None)},
+            Table({"col2": []}),
+            id="no rows, single mapper",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3]}),
+            {"b": lambda row: 2 * row["a"]},
+            Table({"b": [2, 4, 6]}),
+            id="single mapper, computed value",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            {
+                "c": lambda row: row["a"] + row["b"],
+                "d": lambda row: row["a"] * row["b"],
+            },
+            Table({"c": [5, 7, 9], "d": [4, 10, 18]}),
+            id="multiple mappers, computed values",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3]}),
+            {
+                "b": lambda _: Cell.constant(None),
+                "c": lambda row: row["a"] * 10,
+            },
+            Table({"b": [None, None, None], "c": [10, 20, 30]}),
+            id="mix of constant and computed mappers",
+        ),
+        pytest.param(
+            lambda: Table({"a": [1, 2, 3], "b": [4, 5, 6]}),
+            {"a": lambda row: row["b"] * 10},
+            Table({"a": [40, 50, 60]}),
+            id="computed name overlaps existing column",
+        ),
+    ],
+)
+class TestHappyPath:
+    def test_should_select_computed_columns(
+        self,
+        table_factory: Callable[[], Table],
+        mappers: dict[str, Callable],
+        expected: Table,
+    ) -> None:
+        actual = table_factory().select_computed_columns(mappers)
+        assert_tables_are_equal(actual, expected)
+
+    def test_should_not_mutate_receiver(
+        self,
+        table_factory: Callable[[], Table],
+        mappers: dict[str, Callable],
+        expected: Table,  # noqa: ARG002
+    ) -> None:
+        original = table_factory()
+        original.select_computed_columns(mappers)
+        assert_tables_are_equal(original, table_factory())
+
+
+def test_should_propagate_known_types_from_mappers() -> None:
+    table = Table({"a": [1, 2, 3]})
+    result = table.select_computed_columns(
+        {"b": lambda row: row["a"] < 2, "c": lambda row: row["a"] + 10},
+    )
+    assert result.schema.get_column_type("b") == DataTypes.Boolean()
+    assert result.schema.get_column_type("c") == DataTypes.Int64()
+
+
+def test_should_fall_back_to_polars_when_mapper_returns_unknown_type() -> None:
+    table = Table({"a": [1, 2, 3]})
+
+    def mapper(row: Row) -> Cell:
+        cell = row["a"]
+        return ExprCell(cell._polars_expression < 2, type=DataTypes.Unknown())
+
+    result = table.select_computed_columns({"b": mapper})
+    assert result.schema.get_column_type("b") == DataTypes.Boolean()


### PR DESCRIPTION
Closes #215

### Summary of Changes

- Add `select_computed_columns` method to `Table` that computes new columns via mapper callbacks and returns a table containing only those columns, dropping all original columns
